### PR TITLE
✨ Feat: 매물 신고 api 연동 및 텍스트 추가

### DIFF
--- a/src/apis/property.ts
+++ b/src/apis/property.ts
@@ -35,3 +35,13 @@ export const fetchPropertySearch = async (params: FilteredPropertyParams) => {
     count: data?.length ?? 0,
   };
 };
+
+// 매물 신고
+export const postReport = async (body: {
+  targetId: number;
+  targetType: string;
+  documentImageUrls: string[];
+  description: string;
+}) => {
+  return axiosInstance.post("/api/v1/reports", body);
+};

--- a/src/apis/s3Upload.ts
+++ b/src/apis/s3Upload.ts
@@ -8,7 +8,7 @@ export interface PresignedUrlResponse {
 // 인증 타입 enum
 export type VerificationType = "ID_CARD" | "PASSPORT" | "DRIVER_LICENSE";
 
-/* 프로필 이미지 업로드용 Presigned URL 요청*/
+// 프로필 이미지 업로드용 Presigned URL 요청
 export const getProfilePresignedUrl = async (
   fileExtension: string,
 ): Promise<PresignedUrlResponse> => {
@@ -35,7 +35,7 @@ export const getVerificationPresignedUrl = async (
   return res.data.data;
 };
 
-/* 매물 기록 이미지 업로드용 Presigned URL 요청 */
+// 매물 기록 이미지 업로드용 Presigned URL 요청
 export const getPropertyNotePresignedUrl = async (
   fileExtensions: string[],
 ): Promise<PresignedUrlResponse[]> => {
@@ -43,6 +43,19 @@ export const getPropertyNotePresignedUrl = async (
     "/api/v1/s3/viewings/property-notes/presigned-url",
     { fileExtensions },
   );
+
+  return res.data.data;
+};
+
+// 매물 신고용 Presigned URL 요청
+export const getReportPresignedUrls = async (
+  reportTargetType: "PROPERTY" | "USER" | "REVIEW",
+  fileExtensions: string[],
+): Promise<PresignedUrlResponse[]> => {
+  const res = await axiosInstance.post("/api/v1/s3/reports/presigned-url", {
+    reportTargetType,
+    fileExtensions,
+  });
 
   return res.data.data;
 };

--- a/src/app/listings/[id]/report/page.tsx
+++ b/src/app/listings/[id]/report/page.tsx
@@ -1,45 +1,67 @@
 "use client";
 
+import { useParams } from "next/navigation";
+
 import { useEffect, useRef, useState } from "react";
 
+import axios from "axios";
+
+import { postReport } from "@/apis/property";
+import { getReportPresignedUrls } from "@/apis/s3Upload";
+
+import AlertMessage from "@/components/common/AlertMessage";
 import BottomActionBar from "@/components/common/BottomActionBar";
 import CheckIcon from "@/components/common/CheckIcon";
 import Divider from "@/components/common/Divider";
 import ImagePreviewSection from "@/components/common/ImagePreviewSection";
+import LoadingLottie from "@/components/common/LoadingLottie";
 import TextareaField from "@/components/common/TextareaField";
 import ContentWrapper from "@/components/layout/ContentWrapper";
 import BackHeader from "@/components/layout/header/BackHeader";
 
+const MAX_IMAGES = 5;
+const ALLOWED_TYPES = ["image/jpeg", "image/png"];
 const ListingReportPage = () => {
+  const params = useParams();
+  const propertyId = Number(params.id);
+
   const [content, setContent] = useState("");
   const [isChecked, setIsChecked] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [alertMessage, setAlertMessage] = useState<string | null>(null);
 
   const [newImagePreviews, setNewImagePreviews] = useState<string[]>([]);
-  const [, setNewFiles] = useState<File[]>([]);
+  const [newFiles, setNewFiles] = useState<File[]>([]);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleUploadClick = () => fileInputRef.current?.click();
 
-  const isSupportedImage = (file: File) => {
-    const supportedTypes = ["image/jpeg", "image/png"];
-    return supportedTypes.includes(file.type);
-  };
-
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files) return;
 
     const files = Array.from(e.target.files);
-    const validFiles = files.filter(file => isSupportedImage(file));
+    const validFiles = files.filter(file => ALLOWED_TYPES.includes(file.type));
 
     if (validFiles.length < files.length) {
-      alert("지원되지 않는 이미지 형식이 포함되어 있습니다.");
+      setAlertMessage("JPG, PNG 파일만 업로드할 수 있어요");
+      return;
+    }
+
+    const totalCount = newImagePreviews.length + validFiles.length;
+
+    if (totalCount > MAX_IMAGES) {
+      setAlertMessage(
+        `이미지는 최대 ${MAX_IMAGES}장까지 업로드할 수 있습니다.`,
+      );
+      return;
     }
 
     const previews = validFiles.map(file => URL.createObjectURL(file));
 
     setNewImagePreviews(prev => [...prev, ...previews]);
     setNewFiles(prev => [...prev, ...validFiles]);
+    setAlertMessage(""); // 에러 메시지 초기화
   };
 
   const isFormValid =
@@ -50,6 +72,44 @@ const ListingReportPage = () => {
       newImagePreviews.forEach(url => URL.revokeObjectURL(url));
     };
   }, [newImagePreviews]);
+
+  const handleSubmit = async () => {
+    try {
+      setIsLoading(true);
+
+      const extensions = newFiles.map(
+        file => file.name.split(".").pop() || "png",
+      );
+      const presignedUrls = await getReportPresignedUrls(
+        "PROPERTY",
+        extensions,
+      );
+
+      await Promise.all(
+        presignedUrls.map((item, idx) =>
+          axios.put(item.presignedUrl, newFiles[idx], {
+            headers: { "Content-Type": newFiles[idx].type },
+          }),
+        ),
+      );
+
+      await postReport({
+        targetId: propertyId,
+        targetType: "PROPERTY",
+        documentImageUrls: presignedUrls.map(item => item.fileUrl),
+        description: content,
+      });
+
+      setContent("");
+      setIsChecked(false);
+      setNewImagePreviews([]);
+      setNewFiles([]);
+    } catch (err) {
+      console.error("신고 실패", err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   return (
     <ContentWrapper bottomOffset={64}>
@@ -106,14 +166,38 @@ const ListingReportPage = () => {
 
       <ImagePreviewSection
         size="sm"
-        existingImages={[]} // 신고에서는 기존 이미지 없음
+        existingImages={[]}
         setExistingImages={() => {}}
         newImagePreviews={newImagePreviews}
         setNewImagePreviews={setNewImagePreviews}
         setNewFiles={setNewFiles}
+        wrapperClassName="my-2"
       />
 
-      <BottomActionBar label="신고하기" disabled={!isFormValid} />
+      {newImagePreviews.length > 0 && (
+        <span className="text-cap1-med flex px-4 text-gray-600">
+          이미지는 최대 5장까지 업로드할 수 있습니다.
+        </span>
+      )}
+
+      <BottomActionBar
+        label="신고하기"
+        disabled={!isFormValid}
+        onClick={handleSubmit}
+      />
+      {isLoading && (
+        <div className="fixed inset-0 z-[999] flex items-center justify-center bg-white/80 backdrop-blur-[2px]">
+          <LoadingLottie />
+        </div>
+      )}
+
+      {alertMessage && (
+        <AlertMessage
+          message={alertMessage}
+          className="bottom-[76px]"
+          onDone={() => setAlertMessage(null)}
+        />
+      )}
     </ContentWrapper>
   );
 };

--- a/src/components/common/ImagePreviewSection.tsx
+++ b/src/components/common/ImagePreviewSection.tsx
@@ -1,3 +1,5 @@
+import clsx from "clsx";
+
 import CloseIcon from "@/public/svgs/common/close-icon.svg";
 
 type SizeOption = "sm" | "md" | "lg";
@@ -46,7 +48,9 @@ interface ImagePreviewSectionProps {
   setNewImagePreviews: React.Dispatch<React.SetStateAction<string[]>>;
   setNewFiles: React.Dispatch<React.SetStateAction<File[]>>;
   size?: SizeOption;
+  wrapperClassName?: string;
 }
+
 const ImagePreviewSection = ({
   existingImages,
   setExistingImages,
@@ -54,6 +58,7 @@ const ImagePreviewSection = ({
   setNewImagePreviews,
   setNewFiles,
   size = "md",
+  wrapperClassName = "my-4",
 }: ImagePreviewSectionProps) => {
   if (existingImages.length + newImagePreviews.length === 0) return null;
 
@@ -61,7 +66,12 @@ const ImagePreviewSection = ({
     sizeClassMap[size];
 
   return (
-    <div className="scrollbar-hide my-4 max-w-[375px] overflow-x-auto">
+    <div
+      className={clsx(
+        "scrollbar-hide max-w-[375px] overflow-x-auto",
+        wrapperClassName,
+      )}
+    >
       <div className={`inline-flex min-w-fit px-4 ${gap}`}>
         {/* 기존 S3 이미지 */}
         {existingImages.map((src, index) => (


### PR DESCRIPTION
### 🔥 작업 내용
- 매물 신고 페이지 api 연동 완료 및 모달/텍스트 추가하였습니다.
- s3 업로드 될 동안 시간이 좀 걸려서 로딩 로티도 반투명 배경에 띄워 로직 추가하였습니다.

### 🤔 추후 작업 사항
- 다른 페이지들과 이미지 업로드 로직 중복이 있어 따로 이슈 파고 리팩토링하겠습니다

### 🔗 이슈
- #58 
