### PR TITLE
✨ Feat: admin verification detail 구현

### DIFF
--- a/src/app/admin/components/types/verification.tsx
+++ b/src/app/admin/components/types/verification.tsx
@@ -1,7 +1,14 @@
 export interface Verification {
-    id: number;
-    type: "ID_CARD" | "PASSPORT" | "DRIVER_LICENSE" | "RESIDENT_PERMIT";
-    status: "PENDING" | "APPROVED" | "REJECTED";
-    requestedAt: string;
-    memberId: number;
+  id: number;
+  type: "ID_CARD" | "PASSPORT" | "DRIVER_LICENSE" | "RESIDENT_PERMIT";
+  status: "PENDING" | "APPROVED" | "REJECTED";
+  requestedAt: string;
+  memberId: number;
+}
+
+export interface VerificationDetail extends Verification {
+  documentImageUrls: string[];
+  rejectionReason?: string;
+  approvedAt?: string;
+  rejectedAt?: string;
 }

--- a/src/app/admin/components/verification/VerificationDetailModal.tsx
+++ b/src/app/admin/components/verification/VerificationDetailModal.tsx
@@ -29,7 +29,7 @@ const VerificationDetailModal = ({ data, onClose }: Props) => {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-30">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/20">
       <div className="relative w-[600px] rounded-lg bg-white p-8 shadow-xl">
         {/* 닫기 버튼 */}
         <button

--- a/src/app/admin/components/verification/VerificationDetailModal.tsx
+++ b/src/app/admin/components/verification/VerificationDetailModal.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { VerificationDetail } from "../types/verification";
+import Image from "next/image";
+import { useState } from "react";
+
+
+interface Props {
+  data: VerificationDetail; //상세 조회 대상 데이터 
+  onClose: () => void; //모달 닫기 함수 
+}
+
+const VerificationDetailModal = ({ data, onClose }: Props) => {
+  const [rejectionReason, setRejectionReason] = useState("");
+  const [showRejectionField, setShowRejectionField] = useState(false);
+
+  const handleApprove = () => {
+    console.log("승인됨", data.id);
+  };
+
+  const handleReject = () => {
+    setShowRejectionField(true);
+  };
+
+  const handleRejectSubmit = () => {
+    console.log("거부됨", data.id, rejectionReason);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-30">
+      <div className="relative w-[600px] rounded-lg bg-white p-8 shadow-xl">
+        {/* 닫기 버튼 */}
+        <button
+          onClick={onClose}
+          className="absolute right-4 top-4 text-gray-500 hover:text-gray-700"
+        >
+          ✕
+        </button>
+
+        {/* 이미지 */}
+        <div className="mb-4 flex gap-4">
+          {data.documentImageUrls.map((url, idx) => (
+            <Image
+              key={idx}
+              src={url}
+              alt={`인증 이미지 ${idx + 1}`}
+              width={200}
+              height={120}
+              className="rounded border"
+            />
+          ))}
+        </div>
+
+        {/* 공통 정보 */}
+        <div className="space-y-2 text-sm text-gray-800">
+          <p>회원 ID: {data.memberId}</p>
+          <p>인증 유형: {data.type}</p>
+          <p>요청 일시: {new Date(data.requestedAt).toLocaleString("ko-KR")}</p>
+          {data.status === "APPROVED" && (
+            <p>승인 일시: {new Date(data.approvedAt!).toLocaleString("ko-KR")}</p>
+          )}
+          {data.status === "REJECTED" && (
+            <>
+              <p>거부 일시: {new Date(data.rejectedAt!).toLocaleString("ko-KR")}</p>
+              <p>거부 사유: {data.rejectionReason}</p>
+            </>
+          )}
+        </div>
+
+        {/* 상태에 따른 버튼 */}
+        {data.status === "PENDING" && (
+          <div className="mt-6 space-y-4">
+            {!showRejectionField ? (
+              <div className="flex gap-4">
+                <button
+                  onClick={handleApprove}
+                  className="rounded bg-green-600 px-4 py-2 text-white hover:bg-green-700"
+                >
+                  승인
+                </button>
+                <button
+                  onClick={handleReject}
+                  className="rounded bg-red-500 px-4 py-2 text-white hover:bg-red-600"
+                >
+                  거부
+                </button>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <textarea
+                  className="w-full rounded border border-gray-300 p-2 text-sm"
+                  rows={4}
+                  maxLength={100}
+                  placeholder="거부 사유를 입력하세요 (최대 100자)"
+                  value={rejectionReason}
+                  onChange={(e) => setRejectionReason(e.target.value)}
+                />
+                <button
+                  onClick={handleRejectSubmit}
+                  className="rounded bg-red-600 px-4 py-2 text-white hover:bg-red-700"
+                >
+                  거부 사유 제출
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default VerificationDetailModal;

--- a/src/app/admin/components/verification/VerificationDetailModal.tsx
+++ b/src/app/admin/components/verification/VerificationDetailModal.tsx
@@ -25,7 +25,7 @@ const VerificationDetailModal = ({ data, onClose }: Props) => {
 
   const handleRejectSubmit = () => {
     console.log("거부됨", data.id, rejectionReason);
-    alert("거부됨")
+    alert("거부됨");
   };
 
   return (

--- a/src/app/admin/components/verification/VerificationDetailModal.tsx
+++ b/src/app/admin/components/verification/VerificationDetailModal.tsx
@@ -16,6 +16,7 @@ const VerificationDetailModal = ({ data, onClose }: Props) => {
 
   const handleApprove = () => {
     console.log("승인됨", data.id);
+    alert("승인됨");
   };
 
   const handleReject = () => {
@@ -24,6 +25,7 @@ const VerificationDetailModal = ({ data, onClose }: Props) => {
 
   const handleRejectSubmit = () => {
     console.log("거부됨", data.id, rejectionReason);
+    alert("거부됨")
   };
 
   return (

--- a/src/app/admin/verification/page.tsx
+++ b/src/app/admin/verification/page.tsx
@@ -38,7 +38,6 @@ const mockData: VerificationDetail[] = [
 
 
 
-
 const AdminVerificationPage = () => {
     const [requests, setRequests] = useState<Verification[]>([]);
     const [selectedVerification, setSelectedVerification] = useState<VerificationDetail | null>(null);

--- a/src/app/admin/verification/page.tsx
+++ b/src/app/admin/verification/page.tsx
@@ -63,7 +63,7 @@ const AdminVerificationPage = () => {
           <tbody>
             {requests.map((item) => (
               <tr key={item.id}
-                  className="border-b border-gray-100 hover:bg-gray-50"
+                  className="border-b border-gray-100 hover:bg-gray-50 cursor-pointer"
                   onClick={()=>setSelectedVerification(item as VerificationDetail)}>
                 <td className="py-2">{item.memberId}</td>
                 <td className="py-2">{item.type}</td>

--- a/src/app/admin/verification/page.tsx
+++ b/src/app/admin/verification/page.tsx
@@ -1,31 +1,47 @@
 "use client";
 import { useEffect, useState } from "react";
-import { Verification } from "../components/types/verification";
+import { Verification, VerificationDetail } from "../components/types/verification";
+import VerificationDetailModal from "../components/verification/VerificationDetailModal";
 
 
 
 
-const mockData: Verification[] = [
-    {
-      id: 0,
-      type: "ID_CARD",
-      status: "PENDING",
-      requestedAt: "2025-07-18T13:59:28.276Z",
-      memberId: 123,
-    },
-    {
-      id: 1,
-      type: "PASSPORT",
-      status: "APPROVED",
-      requestedAt: "2025-07-16T10:25:00.000Z",
-      memberId: 456,
-    },
-  ]; 
+const mockData: VerificationDetail[] = [
+  {
+    id: 0,
+    type: "ID_CARD",
+    status: "PENDING",
+    requestedAt: "2025-07-18T13:59:28.276Z",
+    memberId: 123,
+    documentImageUrls: ["/sample-id.jpg"], // 예시 이미지
+  },
+  {
+    id: 1,
+    type: "PASSPORT",
+    status: "APPROVED",
+    requestedAt: "2025-07-16T10:25:00.000Z",
+    memberId: 456,
+    documentImageUrls: ["/sample-passport.jpg"],
+    approvedAt: "2025-07-17T08:30:00.000Z",
+  },
+  {
+    id: 2,
+    type: "DRIVER_LICENSE",
+    status: "REJECTED",
+    requestedAt: "2025-07-15T09:00:00.000Z",
+    memberId: 789,
+    documentImageUrls: ["/sample-license.jpg"],
+    rejectedAt: "2025-07-16T10:00:00.000Z",
+    rejectionReason: "사진이 너무 흐립니다.",
+  }
+];
+
 
 
 
 const AdminVerificationPage = () => {
     const [requests, setRequests] = useState<Verification[]>([]);
+    const [selectedVerification, setSelectedVerification] = useState<VerificationDetail | null>(null);
   
     useEffect(() => {
       // api 연동하겠습니다.
@@ -47,7 +63,9 @@ const AdminVerificationPage = () => {
           </thead>
           <tbody>
             {requests.map((item) => (
-              <tr key={item.id} className="border-b border-gray-100 hover:bg-gray-50">
+              <tr key={item.id}
+                  className="border-b border-gray-100 hover:bg-gray-50"
+                  onClick={()=>setSelectedVerification(item as VerificationDetail)}>
                 <td className="py-2">{item.memberId}</td>
                 <td className="py-2">{item.type}</td>
                 <td className="py-2">{new Date(item.requestedAt).toLocaleString("ko-KR")}</td>
@@ -68,6 +86,16 @@ const AdminVerificationPage = () => {
             ))}
           </tbody>
         </table>
+        {/*모달*/}
+        {
+          selectedVerification && (
+            <VerificationDetailModal
+              data={selectedVerification}
+              onClose={() => setSelectedVerification(null)}
+            />
+
+          )
+        }
       </div>
     );
   };


### PR DESCRIPTION
### 🔥 작업 내용
- 관리자 신원인증 전체 조회 페이지에서 각 요소 클릭 시 상세 조회 모달 만들었습니다.

- 신원인증 요청 현 상태(PENDING, APPROVED, REJECTED)에 따라 보여주는 정보 다르게 설정했습니다


### 🤔 추후 작업 사항

- 다시 보니 승인 거부 버튼도 쫌 별로네요... 예쁜 디자인 고민해보겠습니다.

### 📸 작업 내역 스크린샷
<img width="1514" height="750" alt="image" src="https://github.com/user-attachments/assets/f804384d-0bde-4a6b-b35e-2da1270d9fc4" />
<img width="1125" height="811" alt="image" src="https://github.com/user-attachments/assets/cf11b30c-9246-4f85-82a8-8bfcac066208" />
<img width="1110" height="664" alt="image" src="https://github.com/user-attachments/assets/03a3c51a-f42a-4c09-be74-a67b0f09bfc8" />




### 🔗 이슈
- 모달을 components/verification 안에 만들었는데 요런 식으로 위치 잡으면 될까요?
- types에 verificationDetail(상세조회용)을 extends verification(전체조회용)으로 만들었는데, 쫌 별로 인 거 같음. 공통으로 담고 있는 애들을 verification에 넣었는데 나중에 수정해야 하면 복잡해질 거 같아요. 이럴 때 좋은 방법 없나요?



