### PR TITLE
✨ Feat: 즐겨찾기 페이지 api 연동

### DIFF
--- a/src/apis/wishlist.ts
+++ b/src/apis/wishlist.ts
@@ -1,4 +1,5 @@
 import { SummaryProperty } from "@/types/property";
+import { WishListSortType } from "@/types/wishlist";
 
 import { axiosInstance } from "./axios";
 
@@ -16,6 +17,16 @@ export const removeWish = async (propertyId: number) => {
       targetId: propertyId,
     },
   });
+};
+
+export const getWishedProperties = async (
+  sort: WishListSortType = "latest",
+): Promise<SummaryProperty[]> => {
+  const res = await axiosInstance.get("/api/v1/wish-items/properties", {
+    params: { sort },
+  });
+
+  return res.data.data ?? [];
 };
 
 export const getMyWishList = async (): Promise<SummaryProperty[]> => {

--- a/src/app/listings/[id]/report/page.tsx
+++ b/src/app/listings/[id]/report/page.tsx
@@ -21,6 +21,7 @@ import BackHeader from "@/components/layout/header/BackHeader";
 
 const MAX_IMAGES = 5;
 const ALLOWED_TYPES = ["image/jpeg", "image/png"];
+
 const ListingReportPage = () => {
   const params = useParams();
   const propertyId = Number(params.id);

--- a/src/app/wishlist/page.tsx
+++ b/src/app/wishlist/page.tsx
@@ -7,15 +7,21 @@ import { useMemo, useState } from "react";
 import { useAuthStore } from "@/stores/useAuthStore";
 import { useLoginModalStore } from "@/stores/useLoginModalStore";
 
+import {
+  useToggleWish,
+  useWishedProperties,
+} from "@/hooks/wishlist/useWishList";
+
 import BottomActionBar from "@/components/common/BottomActionBar";
 import GuestLoginGuide from "@/components/common/GuestLoginGuide";
+import LoadingLottie from "@/components/common/LoadingLottie";
 import LoginAlertModal from "@/components/common/LoginAlertModal";
 import ContentWrapper from "@/components/layout/ContentWrapper";
 import TitleHeader from "@/components/layout/header/TitleHeader";
 import DropDownMenu from "@/components/wishlist/dropDownMenu";
 import RoomList from "@/components/wishlist/roomList";
 
-import { ListingDummies } from "@/constants/mock/listing-card-dummies";
+import { WishListSortType } from "@/types/wishlist";
 
 import ListIcon from "@/public/svgs/header/list-icon.svg";
 
@@ -26,57 +32,26 @@ const Wishlist = () => {
 
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [isOpen, setIsOpen] = useState(false);
-  const [likedMap, setLikedMap] = useState<Record<number, boolean>>({});
-  const [sortOrder, setSortOrder] = useState<"latest" | "popular">("latest");
 
-  const extractTime = (createdAt: string): number => {
-    return new Date(createdAt).getTime();
-  };
+  const [sortOrder, setSortOrder] = useState<WishListSortType>("latest");
+  const { data: listings = [], isLoading } = useWishedProperties(sortOrder);
+  const { mutate: toggleWish } = useToggleWish(["wishList", sortOrder]);
 
-  const sortedListings = useMemo(() => {
-    if (!isLoggedIn) return [];
-    const likedFiltered = ListingDummies.filter(
-      item => likedMap[item.id] !== false,
-    );
-
-    const available = likedFiltered.filter(
-      item => item.tradeStatus === "BEFORE",
-    );
-    const completed = likedFiltered.filter(
-      item => item.tradeStatus !== "BEFORE",
-    );
-
-    const sortedAvailable = [...available].sort((a, b) => {
-      if (sortOrder === "latest") {
-        return extractTime(b.createdAt) - extractTime(a.createdAt);
-      }
-      if (sortOrder === "popular") {
-        return b.wishCount - a.wishCount;
-      }
-      return 0;
-    });
-
-    return [...sortedAvailable, ...completed];
-  }, [isLoggedIn, sortOrder, likedMap]);
-
-  const ensureLogin = () => {
-    if (isLoggedIn) return true;
-    openModal();
-    return false;
-  };
+  const filteredListings = useMemo(() => {
+    const available = listings.filter(item => item.tradeStatus === "BEFORE");
+    const completed = listings.filter(item => item.tradeStatus !== "BEFORE");
+    return [...available, ...completed];
+  }, [listings]);
 
   const handleRoomClick = (id: number) => {
     if (!ensureLogin()) return;
     setSelectedId(prevId => (prevId === id ? null : id));
   };
 
-  const toggleLike = (id: number) => {
-    if (!ensureLogin()) return;
-    setLikedMap(prev => {
-      const current = prev[id] ?? true;
-      return { ...prev, [id]: !current };
-    });
-    if (selectedId === id) setSelectedId(null);
+  const ensureLogin = () => {
+    if (isLoggedIn) return true;
+    openModal();
+    return false;
   };
 
   const handleNavigate = (type: "overview" | "reservation") => {
@@ -93,6 +68,12 @@ const Wishlist = () => {
       className="relative flex min-h-screen w-full flex-col"
       bottomOffset={selectedId !== null ? 65 : 62}
     >
+      {isLoading && (
+        <div className="fixed inset-0 z-[99] flex items-center justify-center bg-white/80 backdrop-blur-xs">
+          <LoadingLottie />
+        </div>
+      )}
+
       <TitleHeader
         title="즐겨찾기"
         rightIcon={isLoggedIn ? "list" : undefined}
@@ -115,7 +96,7 @@ const Wishlist = () => {
       <div className="text-body2-med flex items-center justify-between px-4 py-3 text-gray-800">
         <div className="flex items-center gap-1">
           <div>즐겨찾기 매물</div>
-          <div>{sortedListings.length}개</div>
+          <div>{filteredListings.length}개</div>
         </div>
         {!isLoggedIn && (
           <button onClick={ensureLogin} className="cursor-pointer">
@@ -128,7 +109,7 @@ const Wishlist = () => {
       {isLoggedIn ? (
         <>
           {/* 매물 리스트 */}
-          {sortedListings.map(item => (
+          {filteredListings.map(item => (
             <div
               key={item.id}
               onClick={() => handleRoomClick(item.id)}
@@ -138,15 +119,14 @@ const Wishlist = () => {
             >
               <RoomList
                 {...item}
-                isLiked={
-                  likedMap[item.id] !== undefined ? likedMap[item.id] : true
+                isLiked={item.metaInfo?.wished ?? false}
+                wishCount={item.wishCount}
+                onToggleLike={() =>
+                  toggleWish({
+                    id: item.id,
+                    isLiked: item.metaInfo?.wished ?? false,
+                  })
                 }
-                wishCount={
-                  likedMap[item.id] !== undefined
-                    ? item.wishCount + (likedMap[item.id] ? 0 : -1)
-                    : item.wishCount
-                }
-                onToggleLike={() => toggleLike(item.id)}
               />
             </div>
           ))}
@@ -172,7 +152,7 @@ const Wishlist = () => {
               onClick: () => handleNavigate("reservation"),
               variant: "filled",
               disabled:
-                sortedListings.find(item => item.id === selectedId)
+                filteredListings.find(item => item.id === selectedId)
                   ?.tradeStatus !== "BEFORE",
             },
           ]}

--- a/src/app/wishlist/page.tsx
+++ b/src/app/wishlist/page.tsx
@@ -35,7 +35,7 @@ const Wishlist = () => {
 
   const [sortOrder, setSortOrder] = useState<WishListSortType>("latest");
   const { data: listings = [], isLoading } = useWishedProperties(sortOrder);
-  const { mutate: toggleWish } = useToggleWish(["wishList", sortOrder]);
+  const { mutate: toggleWish } = useToggleWish([["wishList", sortOrder]]);
 
   const filteredListings = useMemo(() => {
     const available = listings.filter(item => item.tradeStatus === "BEFORE");

--- a/src/components/common/ViewingPostCard.tsx
+++ b/src/components/common/ViewingPostCard.tsx
@@ -43,7 +43,9 @@ export const ViewingPostCard = ({
         <div className="flex flex-col gap-2">
           <div className="flex w-full items-center justify-between">
             <p className="text-body1-sb text-gray-900">주/ {weeklyCost}$</p>
-            <span className="text-cap1-med text-gray-500">{suburb}</span>
+            <span className="text-cap1-med text-gray-500">
+              {suburb.toLowerCase()}
+            </span>
           </div>
 
           <div className="flex flex-col gap-[2px]">

--- a/src/components/home/ListingCard.tsx
+++ b/src/components/home/ListingCard.tsx
@@ -91,7 +91,9 @@ const ListingCard = ({
           </p>
         </div>
 
-        <span className="text-cap1-med text-gray-500">{suburb}</span>
+        <span className="text-cap1-med text-gray-500">
+          {suburb.toLowerCase()}
+        </span>
       </div>
 
       <div className="text-cap1-med flex h-24 flex-col items-end justify-between text-gray-500">

--- a/src/components/home/ListingList.tsx
+++ b/src/components/home/ListingList.tsx
@@ -7,15 +7,14 @@ import { useMemo, useState } from "react";
 import { useAuthStore } from "@/stores/useAuthStore";
 import { useFilterStore } from "@/stores/useFilterStore";
 import { useLoginModalStore } from "@/stores/useLoginModalStore";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import "dayjs/locale/ko";
 import relativeTime from "dayjs/plugin/relativeTime";
 import utc from "dayjs/plugin/utc";
 
-import { addWish, removeWish } from "@/apis/wishlist";
-
 import { usePropertySearch } from "@/hooks/filter/useFilter";
+import { useToggleWish } from "@/hooks/wishlist/useWishList";
 
 import { buildQueryParams } from "@/utils/buildQueryParams";
 
@@ -112,35 +111,37 @@ const ListingList = ({ fallbackSuburb }: { fallbackSuburb: string | null }) => {
     setLikedMap(initLiked);
   }, [properties]);
 
-  const mutation = useMutation({
-    mutationFn: async ({ id, isLiked }: { id: number; isLiked: boolean }) => {
-      if (isLiked) {
-        await removeWish(id);
-      } else {
-        await addWish(id);
-      }
-    },
-    onMutate: async ({ id, isLiked }) => {
-      setLikeCounts(prev => ({
-        ...prev,
-        [id]: prev[id] + (isLiked ? -1 : 1),
-      }));
-      setLikedMap(prev => ({
-        ...prev,
-        [id]: !isLiked,
-      }));
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ["wishList"] });
-    },
-  });
+  const { mutate: toggleWish } = useToggleWish();
 
   const handleToggleLike = (id: number, isLiked: boolean) => {
     if (!isLoggedIn) {
       openModal();
       return;
     }
-    mutation.mutate({ id, isLiked });
+
+    setLikeCounts(prev => ({
+      ...prev,
+      [id]: prev[id] + (isLiked ? -1 : 1),
+    }));
+    setLikedMap(prev => ({
+      ...prev,
+      [id]: !isLiked,
+    }));
+
+    toggleWish(
+      { id, isLiked },
+      {
+        onSettled: () => {
+          queryClient.invalidateQueries({
+            predicate: query => query.queryKey[0] === "propertySearch",
+          });
+          queryClient.refetchQueries({
+            queryKey: ["wishList", "latest"],
+            type: "all",
+          });
+        },
+      },
+    );
   };
 
   const handleCardClick = (id: number) => {

--- a/src/components/wishlist/dropDownMenu.tsx
+++ b/src/components/wishlist/dropDownMenu.tsx
@@ -4,8 +4,10 @@ import { useClickOutside } from "@/hooks/common/useClickOutside";
 
 import Divider from "@/components/common/Divider";
 
+import { WishListSortType } from "@/types/wishlist";
+
 interface DropDownMenuProps {
-  onSelect: (order: "latest" | "popular") => void;
+  onSelect: (order: WishListSortType) => void;
   onClose: () => void;
 }
 const DropDownMenu = ({ onSelect, onClose }: DropDownMenuProps) => {

--- a/src/components/wishlist/roomList.tsx
+++ b/src/components/wishlist/roomList.tsx
@@ -110,7 +110,7 @@ const RoomList = ({
                 <EmptyHeart className={`${heartColor} h-6 w-6`} />
               )}
             </div>
-            <div className="text-cap1-med text-right text-gray-400">
+            <div className="text-cap1-med text-center text-gray-400">
               {wishCount}
             </div>
           </div>

--- a/src/components/wishlist/roomList.tsx
+++ b/src/components/wishlist/roomList.tsx
@@ -46,7 +46,7 @@ const RoomList = ({
       )}
     >
       <Image
-        src={thumbnailUrl ?? "/svgs/common/room-img.svg"}
+        src={thumbnailUrl ?? ""}
         alt="thumbnail"
         width={108}
         height={108}
@@ -60,7 +60,7 @@ const RoomList = ({
           {/* 가격 + 상태 */}
           <div className="flex flex-row gap-[6px] pb-2">
             <div className="text-body1-sb text-gray-900">
-              {weeklyCost.toLocaleString()}원
+              주/ {weeklyCost.toLocaleString()}$
             </div>
             <div
               className={clsx(
@@ -89,7 +89,9 @@ const RoomList = ({
             <div> {getDistanceInKm(nearestStation.distanceFromStation)}km</div>
           </div>
 
-          <div className="text-cap1-med text-gray-500">{suburb}</div>
+          <div className="text-cap1-med text-gray-500">
+            {suburb.toLowerCase()}
+          </div>
         </div>
 
         {/* 우측 하트 및 시간 */}
@@ -103,12 +105,12 @@ const RoomList = ({
               className="cursor-pointer"
             >
               {isLiked ? (
-                <FilledHeart className={heartColor} />
+                <FilledHeart className={`${heartColor} h-6 w-6`} />
               ) : (
-                <EmptyHeart className={heartColor} />
+                <EmptyHeart className={`${heartColor} h-6 w-6`} />
               )}
             </div>
-            <div className="text-cap1-med text-center text-gray-400">
+            <div className="text-cap1-med text-right text-gray-400">
               {wishCount}
             </div>
           </div>

--- a/src/hooks/wishlist/useWishList.ts
+++ b/src/hooks/wishlist/useWishList.ts
@@ -1,5 +1,10 @@
 import { useAuthStore } from "@/stores/useAuthStore";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  QueryKey,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 
 import {
   addWish,
@@ -24,12 +29,11 @@ export const useWishedProperties = (sort: WishListSortType = "latest") => {
   return useQuery({
     queryKey: ["wishList", sort],
     queryFn: () => getWishedProperties(sort),
+    staleTime: 0,
   });
 };
 
-export const useToggleWish = (
-  refetchKey: (string | number)[] = ["wishList"],
-) => {
+export const useToggleWish = (refetchKeys: QueryKey[] = [["wishList"]]) => {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -41,7 +45,9 @@ export const useToggleWish = (
       }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: refetchKey });
+      refetchKeys.forEach(key => {
+        queryClient.invalidateQueries({ queryKey: key });
+      });
     },
   });
 };

--- a/src/hooks/wishlist/useWishList.ts
+++ b/src/hooks/wishlist/useWishList.ts
@@ -1,7 +1,14 @@
 import { useAuthStore } from "@/stores/useAuthStore";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { getMyWishList } from "@/apis/wishlist";
+import {
+  addWish,
+  getMyWishList,
+  getWishedProperties,
+  removeWish,
+} from "@/apis/wishlist";
+
+import { WishListSortType } from "@/types/wishlist";
 
 export const useWishList = () => {
   const isLoggedIn = useAuthStore(state => state.isLoggedIn);
@@ -10,5 +17,31 @@ export const useWishList = () => {
     queryKey: ["wishList"],
     queryFn: getMyWishList,
     enabled: isLoggedIn,
+  });
+};
+
+export const useWishedProperties = (sort: WishListSortType = "latest") => {
+  return useQuery({
+    queryKey: ["wishList", sort],
+    queryFn: () => getWishedProperties(sort),
+  });
+};
+
+export const useToggleWish = (
+  refetchKey: (string | number)[] = ["wishList"],
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, isLiked }: { id: number; isLiked: boolean }) => {
+      if (isLiked) {
+        await removeWish(id);
+      } else {
+        await addWish(id);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: refetchKey });
+    },
   });
 };

--- a/src/types/wishlist.ts
+++ b/src/types/wishlist.ts
@@ -1,0 +1,1 @@
+export type WishListSortType = "latest" | "popular";

--- a/src/utils/propertyFormatter.ts
+++ b/src/utils/propertyFormatter.ts
@@ -4,5 +4,4 @@ export const getDisplayStatus = (tradeStatus: string) =>
 export const getDisplayType = (kind: string) =>
   kind === "SHARE" ? "쉐어" : "렌트";
 
-export const getDistanceInKm = (distance: number) =>
-  (distance / 1000).toFixed(1);
+export const getDistanceInKm = (distance: number) => distance.toFixed(1);


### PR DESCRIPTION
### 🔥 작업 내용
- 즐겨찾기 페이지에 실제 API 연동을 완료했습니다.
- 드롭다운 선택 시 쿼리 파라미터가 변경되어 목록이 정렬됩니다.
- 홈 화면에서 사용되는 매물 목록에서도 useToggleWish 훅을 사용하도록 공통화 리팩토링했습니다.
  - 즐겨찾기 토글 시, API 응답 정보를 곧바로 반영할 수 있도록 invalidateQueries를 통해 관련 쿼리를 무효화했습니다.
  - 페이지를 새로고침하지 않고 즐겨찾기 페이지로 이동할 경우에도, 방금 찜한 항목이 바로 반영되도록 staleTime 설정을 추가했습니다. 

### 📸 작업 내역 스크린샷

https://github.com/user-attachments/assets/c6d5789e-65fd-4000-985b-4e818aaf4962


### 🔗 이슈

- #71 
