### PR TITLE
✨ Feat: 내놓은 매물 숨기기 api 연동 및 뷰잉 거래 파라미터 추가

### DIFF
--- a/src/apis/property.ts
+++ b/src/apis/property.ts
@@ -91,12 +91,14 @@ export const getMyPropertiesWithFilter = async (params: MyPropertiesParams) => {
 export const completeTrade = async ({
   propertyId,
   viewingId,
+  dealWithOutsider,
 }: {
   propertyId: number;
-  viewingId: number;
+  viewingId?: number;
+  dealWithOutsider: boolean;
 }) => {
   const res = await axiosInstance.post(
-    `/api/v1/properties/${propertyId}/complete?viewingId=${viewingId}`,
+    `/api/v1/properties/${propertyId}/complete?viewingId=${viewingId}?dealWithOutsider=${dealWithOutsider}`,
   );
   return res.data.data;
 };

--- a/src/apis/property.ts
+++ b/src/apis/property.ts
@@ -10,6 +10,7 @@ import { FilteredPropertyParams } from "@/types/property";
 
 import { axiosInstance } from "./axios";
 
+// 매물 목록 조회
 export const fetchPropertyList = async <T extends PropertyViewType>(
   view: T,
 ): Promise<T extends "SUMMARY" ? SummaryProperty[] : Property[]> => {
@@ -17,6 +18,7 @@ export const fetchPropertyList = async <T extends PropertyViewType>(
   return res.data.data;
 };
 
+// 매물 상세 조회
 export const fetchPropertyDetailList = async (
   propertyId: string,
 ): Promise<Property> => {
@@ -24,6 +26,32 @@ export const fetchPropertyDetailList = async (
   return res.data.data;
 };
 
+// 매물 수정
+export const patchProperty = async (propertyId: number, payload: Property) => {
+  const res = await axiosInstance.patch(
+    `/api/v1/properties/${propertyId}`,
+    payload,
+  );
+  return res.data.data;
+};
+
+export const patchDisplayStatus = (
+  propertyId: number,
+  payload: {
+    jsonDiscriminator: "SHARE" | "RENT";
+    displayStatus: "ACTIVE" | "INACTIVE";
+  },
+) => {
+  return axiosInstance.patch(`/api/v1/properties/${propertyId}`, payload);
+};
+
+// 매물 삭제
+export const deleteProperty = async (propertyId: number) => {
+  const res = await axiosInstance.delete(`/api/v1/properties/${propertyId}`);
+  return res.data.data;
+};
+
+// 매물 검색 필터링
 export const fetchPropertySearch = async (params: FilteredPropertyParams) => {
   const searchParams = serializePropertyFilters(params);
   const queryString = searchParams.toString();

--- a/src/app/listings/[id]/guests/page.tsx
+++ b/src/app/listings/[id]/guests/page.tsx
@@ -34,7 +34,13 @@ const ListingsGuests = () => {
   };
 
   const handleSave = () => {
-    if (checked) {
+    const isDealWithOutsider = checked;
+
+    if (isDealWithOutsider) {
+      completeTrade({
+        propertyId: listingId,
+        dealWithOutsider: true,
+      });
       return;
     }
 
@@ -44,6 +50,7 @@ const ListingsGuests = () => {
     completeTrade({
       propertyId: listingId,
       viewingId: guest.viewingId,
+      dealWithOutsider: false,
     });
   };
 

--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -261,8 +261,13 @@ const ListingDetailPage = () => {
         />
       )}
 
-      {isModalOpen && (
-        <ListingHideModal onClose={() => setIsModalOpen(false)} />
+      {isModalOpen && viewingGuests && (
+        <ListingHideModal
+          listingId={data.id}
+          kind={data.kind}
+          viewingIds={viewingGuests.map(v => v.viewingId)}
+          onClose={() => setIsModalOpen(false)}
+        />
       )}
     </>
   );

--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -5,7 +5,11 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 
 import { useState } from "react";
 
-import { usePropertyDetailList } from "@/hooks/property/useProperty";
+import {
+  usePatchDisplayStatus,
+  usePropertyDetailList,
+} from "@/hooks/property/useProperty";
+import { useViewingGuests } from "@/hooks/viewing/useViewing";
 import { useToggleWish } from "@/hooks/wishlist/useWishList";
 
 import BottomActionBar from "@/components/common/BottomActionBar";
@@ -39,7 +43,40 @@ const ListingDetailPage = () => {
     usePropertyDetailList(listingId);
   const [tradeStatus, setTradeStatus] = useState(data?.tradeStatus);
 
+  const { data: viewingGuests } = useViewingGuests(Number(listingId));
   const { mutate: toggleWish } = useToggleWish();
+  const { mutate: patchDisplayStatus } = usePatchDisplayStatus(
+    Number(listingId),
+  );
+
+  const handleHideClick = () => {
+    setIsClicked(false);
+
+    if (!data?.kind || (data.kind !== "SHARE" && data.kind !== "RENT")) return;
+
+    if (
+      data.displayStatus === "ACTIVE" &&
+      viewingGuests &&
+      viewingGuests.length > 0
+    ) {
+      setIsModalOpen(true);
+      return;
+    }
+
+    const nextStatus = data.displayStatus === "ACTIVE" ? "INACTIVE" : "ACTIVE";
+
+    patchDisplayStatus(
+      {
+        displayStatus: nextStatus,
+        jsonDiscriminator: data.kind,
+      },
+      {
+        onSuccess: () => {
+          router.push("/mypage/listings");
+        },
+      },
+    );
+  };
 
   if (isLoading) return <></>; //추후 스켈레톤 UI
   if (isError || !data) return <></>;
@@ -219,7 +256,8 @@ const ListingDetailPage = () => {
       {isClicked && (
         <BottomSheet
           onClose={() => setIsClicked(false)}
-          onHideClick={() => setIsModalOpen(true)}
+          onHideClick={handleHideClick}
+          displayStatus={data.displayStatus as "ACTIVE" | "INACTIVE"}
         />
       )}
 

--- a/src/app/mypage/listings/page.tsx
+++ b/src/app/mypage/listings/page.tsx
@@ -31,6 +31,7 @@ const Listings = () => {
         return {
           view: "SUMMARY",
           tradeStatus: "BEFORE",
+          displayStatus: "ACTIVE",
         } as const;
       case "completed":
         return {
@@ -45,7 +46,10 @@ const Listings = () => {
     }
   }, [activeTab]);
 
-  const { data, isLoading } = useMyProperties(params);
+  const { data, isLoading } = useMyProperties(params, {
+    staleTime: 0,
+    refetchOnMount: true,
+  });
 
   return (
     <div>

--- a/src/components/listings/BottomSheet.tsx
+++ b/src/components/listings/BottomSheet.tsx
@@ -7,9 +7,14 @@ import Divider from "@/components/common/Divider";
 interface BottomSheetProps {
   onClose: () => void;
   onHideClick: () => void;
+  displayStatus?: "ACTIVE" | "INACTIVE";
 }
 
-const BottomSheet = ({ onClose, onHideClick }: BottomSheetProps) => {
+const BottomSheet = ({
+  onClose,
+  onHideClick,
+  displayStatus,
+}: BottomSheetProps) => {
   const { id } = useParams();
   const router = useRouter();
 
@@ -65,7 +70,7 @@ const BottomSheet = ({ onClose, onHideClick }: BottomSheetProps) => {
           className="text-body1-sb w-full cursor-pointer py-2 text-center text-gray-900"
           onClick={handleHideClick}
         >
-          숨기기
+          {displayStatus === "ACTIVE" ? "숨기기" : "숨기기 취소"}
         </div>
         <Divider className="my-1" />
         <div

--- a/src/components/mypage/ListingHideModal.tsx
+++ b/src/components/mypage/ListingHideModal.tsx
@@ -1,10 +1,65 @@
+import { useRouter } from "next/navigation";
+
+import { usePatchDisplayStatus } from "@/hooks/property/useProperty";
+import { useCancelViewing } from "@/hooks/viewing/useViewing";
+
 import AlertModal from "@/components/common/AlertModal";
 
 interface ListingHideModalProps {
   onClose: () => void;
+  listingId: number;
+  kind: "SHARE" | "RENT";
+  viewingIds: number[];
 }
 
-const ListingHideModal = ({ onClose }: ListingHideModalProps) => {
+const ListingHideModal = ({
+  onClose,
+  listingId,
+  kind,
+  viewingIds,
+}: ListingHideModalProps) => {
+  const { mutate: patchDisplayStatus } = usePatchDisplayStatus(listingId);
+  const { mutateAsync: cancelViewing } = useCancelViewing();
+  const router = useRouter();
+
+  const handleCancelAndHide = async () => {
+    try {
+      await Promise.all(
+        viewingIds.map(viewingId =>
+          cancelViewing({
+            viewingId,
+            optionItemId: 100,
+            reason: "매물 숨김 처리로 인한 예약 취소",
+          }),
+        ),
+      );
+
+      patchDisplayStatus(
+        { displayStatus: "INACTIVE", jsonDiscriminator: kind },
+        {
+          onSuccess: () => {
+            onClose();
+            router.push("/mypage/listings");
+          },
+        },
+      );
+    } catch (err) {
+      console.error("예약 취소 실패", err);
+    }
+  };
+
+  const handleHideOnly = () => {
+    patchDisplayStatus(
+      { displayStatus: "INACTIVE", jsonDiscriminator: kind },
+      {
+        onSuccess: () => {
+          onClose();
+          router.push("/mypage/listings");
+        },
+      },
+    );
+  };
+
   return (
     <AlertModal
       title="이 매물에 확정된 뷰잉 예약이 있어요"
@@ -15,16 +70,9 @@ const ListingHideModal = ({ onClose }: ListingHideModalProps) => {
       ]}
       onClose={onClose}
       actionLabel="예약 취소 후 숨기기"
-      onActionClick={() => {
-        // TODO: 예약 취소 및 숨기기 로직
-        onClose();
-      }}
+      onActionClick={handleCancelAndHide}
       subActionLabel="숨기기만 하기"
-      onSubActionClick={() => {
-        // TODO: 숨기기만 하기 로직
-        console.log("숨기기만 하기");
-        onClose();
-      }}
+      onSubActionClick={handleHideOnly}
     />
   );
 };

--- a/src/components/viewings/CancelReasonModal.tsx
+++ b/src/components/viewings/CancelReasonModal.tsx
@@ -22,17 +22,25 @@ const CancelReasonModal = ({
   if (!isOpen) return null;
   if (isLoading || !cancelDetail || !options) return <></>;
 
-  const label = cancelDetail.cancelReasonOptionItemIds
-    .map(id => {
-      const found = options.find(opt => opt.optionItemId === id);
-      return found ? found.itemName : "알 수 없음";
-    })
-    .join(", ");
+  const hasOptionIds = cancelDetail.cancelReasonOptionItemIds?.length > 0;
 
-  const isEtcSelected = cancelDetail.cancelReasonOptionItemIds.some(id => {
-    const found = options.find(opt => opt.optionItemId === id);
-    return found?.itemName === "기타";
-  });
+  const isEtcSelected =
+    cancelDetail.cancelReasonOptionItemIds?.some(id => {
+      const found = options.find(opt => opt.optionItemId === id);
+      return found?.itemName === "기타";
+    }) ||
+    (!hasOptionIds && !!cancelDetail.reason); // 사유만 있을 때도 기타로 간주
+
+  const label = hasOptionIds
+    ? cancelDetail.cancelReasonOptionItemIds
+        .map(id => {
+          const found = options.find(opt => opt.optionItemId === id);
+          return found ? found.itemName : "알 수 없음";
+        })
+        .join(", ")
+    : cancelDetail.reason
+      ? "기타"
+      : undefined;
 
   return (
     <ModalLayout
@@ -46,9 +54,11 @@ const CancelReasonModal = ({
         </h1>
 
         <div className="flex flex-col gap-9">
-          <span className="text-body1-med bg-gray-0 rounded p-3 text-gray-700">
-            {label}
-          </span>
+          {label && (
+            <span className="text-body1-med bg-gray-0 rounded p-3 text-gray-700">
+              {label}
+            </span>
+          )}
 
           {isEtcSelected && (
             <div className="flex flex-col gap-3">

--- a/src/components/viewings/ViewingManageCard.tsx
+++ b/src/components/viewings/ViewingManageCard.tsx
@@ -77,16 +77,14 @@ const ViewingManageCard = ({
                   <span className="text-cap1-b text-gray-700">노트에 기록</span>
                 </button>
                 <div className="h-3 w-px bg-gray-500" />
-                <button
-                  onClick={onArrowClick}
-                  className="flex w-1/2 cursor-pointer flex-col items-center justify-center"
-                >
-                  <span className="text-cap1-b text-gray-700">
-                    취소 사유 확인
-                  </span>
-                </button>
               </>
             )}
+            <button
+              onClick={onArrowClick}
+              className="flex w-1/2 cursor-pointer flex-col items-center justify-center"
+            >
+              <span className="text-cap1-b text-gray-700">취소 사유 확인</span>
+            </button>
           </div>
         ) : (
           <div className="flex w-full items-center justify-center overflow-hidden rounded border border-gray-300 py-2">

--- a/src/hooks/property/useProperty.ts
+++ b/src/hooks/property/useProperty.ts
@@ -124,10 +124,12 @@ export const useCompleteTrade = () => {
     mutationFn: ({
       propertyId,
       viewingId,
+      dealWithOutsider,
     }: {
       propertyId: number;
-      viewingId: number;
-    }) => completeTrade({ propertyId, viewingId }),
+      viewingId?: number;
+      dealWithOutsider: boolean;
+    }) => completeTrade({ propertyId, viewingId, dealWithOutsider }),
 
     onSuccess: () => {
       router.push("/mypage/listings");

--- a/src/hooks/property/useProperty.ts
+++ b/src/hooks/property/useProperty.ts
@@ -1,13 +1,22 @@
 import { useRouter } from "next/navigation";
 
-import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  UseQueryOptions,
+  UseQueryResult,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 
 import {
   completeTrade,
+  deleteProperty,
   fetchPropertyDetailList,
   fetchPropertyList,
   getMyDeals,
   getMyPropertiesWithFilter,
+  patchDisplayStatus,
+  patchProperty,
 } from "@/apis/property";
 
 import {
@@ -33,17 +42,78 @@ export const usePropertyDetailList = (propertyId: string) => {
     queryKey: ["propertyDetailList", propertyId],
     queryFn: () => fetchPropertyDetailList(propertyId),
     enabled: !!propertyId,
-    staleTime: 1000 * 60 * 5,
+    staleTime: 0,
+    refetchOnMount: true,
   });
 };
 
-export const useMyProperties = (params: MyPropertiesParams) => {
+// 매물 수정
+export const usePatchProperty = (propertyId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: Property) => patchProperty(propertyId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["propertyDetailList", propertyId],
+      });
+    },
+  });
+};
+
+// 매물 숨기기
+export const usePatchDisplayStatus = (propertyId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      displayStatus,
+      jsonDiscriminator,
+    }: {
+      displayStatus: "ACTIVE" | "INACTIVE";
+      jsonDiscriminator: "SHARE" | "RENT";
+    }) => {
+      return patchDisplayStatus(propertyId, {
+        jsonDiscriminator,
+        displayStatus,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["propertyDetailList", propertyId],
+      });
+      queryClient.invalidateQueries({ queryKey: ["my-properties"] });
+    },
+  });
+};
+
+// 매물 삭제
+export const useDeleteProperty = (propertyId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => deleteProperty(propertyId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["my-properties"] });
+    },
+  });
+};
+
+export const useMyProperties = (
+  params: MyPropertiesParams,
+  options?: Omit<
+    UseQueryOptions<SummaryProperty[], Error>,
+    "queryKey" | "queryFn"
+  >,
+): UseQueryResult<SummaryProperty[], Error> => {
   const { view, tradeStatus, displayStatus } = params;
 
   return useQuery({
     queryKey: ["my-properties", view, tradeStatus, displayStatus],
     queryFn: () => getMyPropertiesWithFilter(params),
     enabled: !!view,
+    staleTime: 0,
+    ...options,
   });
 };
 

--- a/src/hooks/viewing/useViewing.ts
+++ b/src/hooks/viewing/useViewing.ts
@@ -109,5 +109,6 @@ export const useViewingGuests = (propertyId: number) => {
     queryKey: ["viewingGuests", propertyId],
     queryFn: () => fetchViewingGuests(propertyId),
     enabled: !!propertyId,
+    staleTime: 0,
   });
 };


### PR DESCRIPTION
### 🔥 작업 내용
- 내놓은 매물 숨기기 API를 연동했습니다. 
기존 매물 수정 api에서 displayStatus 값만 INACTIVE 또는 ACTIVE로 변경하여 매물 노출 여부를 변경합니다.
- 숨긴 매물인 경우, 바텀시트 모달에 '숨기기 취소' 텍스트가 렌더링되고, 선택 시 displayStatus: "ACTIVE"로 변경됩니다.
- 하니홈 외부인과의 거래를 고려해 거래 완료 api에 dealWithOutsider를 필수 파라미터로 추가, viewingId는 옵셔널로 처리하였습니다.
- 취소 상태인 뷰잉 목록 중 버튼이 렌더링되지 않던 문제를 수정하였습니다.

### 🔗 이슈
- #76 