### PR TITLE
🐛 Fix: 상세 페이지 지도공개 여부 로직 수정 및 뷰잉 예약 툴팁 추가

### DIFF
--- a/src/apis/viewing.ts
+++ b/src/apis/viewing.ts
@@ -75,6 +75,14 @@ export const cancelViewing = async (
   });
 };
 
+// 뷰잉 일괄 취소
+export const cancelAllViewings = async (propertyId: number) => {
+  const res = await axiosInstance.patch(
+    `/api/v1/properties/${propertyId}/viewings/cancel-all`,
+  );
+  return res.data.data;
+};
+
 // 뷰잉 취소 사유 조회
 export const getViewingCancelReason = async (viewingId: number) => {
   const res = await axiosInstance.get(`/api/v1/viewings/${viewingId}/cancel`);

--- a/src/apis/viewing.ts
+++ b/src/apis/viewing.ts
@@ -139,9 +139,13 @@ export const putViewingChecklists = async ({
 // 뷰잉 예약한 게스트 목록 조회
 export const fetchViewingGuests = async (
   propertyId: number,
+  status?: ViewingStatus[],
 ): Promise<ViewingGuest[]> => {
+  const searchParams = new URLSearchParams();
+  status?.forEach(s => searchParams.append("status", s));
+
   const res = await axiosInstance.get(
-    `/api/v1/properties/${propertyId}/viewings`,
+    `/api/v1/properties/${propertyId}/viewings?${searchParams.toString()}`,
   );
   return res.data.data;
 };

--- a/src/app/listings/[id]/guests/page.tsx
+++ b/src/app/listings/[id]/guests/page.tsx
@@ -23,7 +23,10 @@ const ListingsGuests = () => {
     null,
   );
 
-  const { data: guests } = useViewingGuests(listingId);
+  const { data: guests } = useViewingGuests(listingId, [
+    "REQUESTED",
+    "COMPLETED",
+  ]);
   const { mutate: completeTrade } = useCompleteTrade();
 
   const showBottomBar = checked || selectedGuestIndex !== null;

--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -43,7 +43,10 @@ const ListingDetailPage = () => {
     usePropertyDetailList(listingId);
   const [tradeStatus, setTradeStatus] = useState(data?.tradeStatus);
 
-  const { data: viewingGuests } = useViewingGuests(Number(listingId));
+  const { data: viewingGuests } = useViewingGuests(Number(listingId), [
+    "REQUESTED",
+    "COMPLETED",
+  ]);
   const { mutate: toggleWish } = useToggleWish();
   const { mutate: patchDisplayStatus } = usePatchDisplayStatus(
     Number(listingId),

--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -268,7 +268,6 @@ const ListingDetailPage = () => {
         <ListingHideModal
           listingId={data.id}
           kind={data.kind}
-          viewingIds={viewingGuests.map(v => v.viewingId)}
           onClose={() => setIsModalOpen(false)}
         />
       )}

--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -261,6 +261,7 @@ const ListingDetailPage = () => {
           onClick={() => router.push("/home")}
         />
       )}
+
       {isEditMode && tradeStatus === "COMPLETED" && (
         <BottomActionBar
           label="거래한 게스트 입력하기"

--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -3,7 +3,9 @@
 import Image from "next/image";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
+
+import { useAuthStore } from "@/stores/useAuthStore";
 
 import {
   usePatchDisplayStatus,
@@ -28,21 +30,20 @@ import HeartOutlineIcon from "@/public/svgs/common/heart-outline-icon.svg";
 const ListingDetailPage = () => {
   const { id } = useParams();
   const listingId = id as string;
-
+  const router = useRouter();
   const mode = useSearchParams().get("mode");
+
+  const { memberId } = useAuthStore();
+
   const isConfirmMode = mode === "confirm";
   const isViewingMode = mode === "viewing";
   const isEditMode = mode === "edit";
 
-  const router = useRouter();
-
-  const [isClicked, setIsClicked] = useState(false); //바텀시트
-  const [isModalOpen, setIsModalOpen] = useState(false); //숨기기모달
+  const [isClicked, setIsClicked] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const { data, isLoading, isError, refetch } =
     usePropertyDetailList(listingId);
-  const [tradeStatus, setTradeStatus] = useState(data?.tradeStatus);
-
   const { data: viewingGuests } = useViewingGuests(Number(listingId), [
     "REQUESTED",
     "COMPLETED",
@@ -52,38 +53,58 @@ const ListingDetailPage = () => {
     Number(listingId),
   );
 
+  const [tradeStatus, setTradeStatus] = useState(data?.tradeStatus);
+
+  const isMyListing = useMemo(
+    () => data?.hostSummary?.id === Number(memberId),
+    [data, memberId],
+  );
+  const isMyReservedListing = useMemo(
+    () =>
+      viewingGuests?.some(guest => guest.guestId === Number(memberId)) ?? false,
+    [viewingGuests, memberId],
+  );
+
+  const isReservationConfirmed = useMemo(
+    () =>
+      isMyListing ||
+      isMyReservedListing ||
+      isConfirmMode ||
+      isViewingMode ||
+      isEditMode,
+    [
+      isMyListing,
+      isMyReservedListing,
+      isConfirmMode,
+      isViewingMode,
+      isEditMode,
+    ],
+  );
+
   const handleHideClick = () => {
     setIsClicked(false);
-
     if (!data?.kind || (data.kind !== "SHARE" && data.kind !== "RENT")) return;
 
-    if (
-      data.displayStatus === "ACTIVE" &&
-      viewingGuests &&
-      viewingGuests.length > 0
-    ) {
+    const hasGuests = viewingGuests && viewingGuests.length > 0;
+    const isActive = data.displayStatus === "ACTIVE";
+
+    if (isActive && hasGuests) {
       setIsModalOpen(true);
       return;
     }
 
-    const nextStatus = data.displayStatus === "ACTIVE" ? "INACTIVE" : "ACTIVE";
-
     patchDisplayStatus(
       {
-        displayStatus: nextStatus,
+        displayStatus: isActive ? "INACTIVE" : "ACTIVE",
         jsonDiscriminator: data.kind,
       },
       {
-        onSuccess: () => {
-          router.push("/mypage/listings");
-        },
+        onSuccess: () => router.push("/mypage/listings"),
       },
     );
   };
 
-  if (isLoading) return <></>; //추후 스켈레톤 UI
-  if (isError || !data) return <></>;
-
+  if (isLoading || isError || !data) return null;
   return (
     <>
       <div className="flex min-h-screen flex-col pb-16">
@@ -227,9 +248,7 @@ const ListingDetailPage = () => {
             <span className="text-heading3 text-gray-900">위치</span>
             <AddressMap
               region={data.region}
-              isReservationConfirmed={
-                isConfirmMode || isViewingMode || isEditMode
-              }
+              isReservationConfirmed={isReservationConfirmed}
             />
           </div>
         </div>

--- a/src/app/mypage/purchases/page.tsx
+++ b/src/app/mypage/purchases/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useRouter } from "next/navigation";
+
 import { useMyDeals } from "@/hooks/property/useProperty";
 
 import LoadingLottie from "@/components/common/LoadingLottie";
@@ -8,7 +10,7 @@ import BackHeader from "@/components/layout/header/BackHeader";
 
 const Purchases = () => {
   const { data: purchases, isLoading } = useMyDeals("DEAL_AS_GUEST");
-
+  const router = useRouter();
   return (
     <div className="flex min-h-screen flex-col">
       <BackHeader />
@@ -28,6 +30,7 @@ const Purchases = () => {
             isLiked={false}
             onToggleLike={() => {}}
             heartColor="text-gray-400"
+            onClick={() => router.push(`/listings/${item.id}?mode=confirm`)}
           />
         ))
       )}

--- a/src/app/mypage/purchases/page.tsx
+++ b/src/app/mypage/purchases/page.tsx
@@ -30,7 +30,7 @@ const Purchases = () => {
             isLiked={false}
             onToggleLike={() => {}}
             heartColor="text-gray-400"
-            onClick={() => router.push(`/listings/${item.id}?mode=confirm`)}
+            onClick={() => router.push(`/listings/${item.id}`)}
           />
         ))
       )}

--- a/src/app/viewing/reservation/[id]/complete/page.tsx
+++ b/src/app/viewing/reservation/[id]/complete/page.tsx
@@ -14,6 +14,7 @@ const ViewingCompletePage = () => {
 
   useEffect(() => {
     queryClient.invalidateQueries({ queryKey: ["myViewingList"] });
+    sessionStorage.setItem("showViewingTooltip", "true");
   }, [queryClient]);
 
   return (

--- a/src/app/viewing/reservation/[id]/confirm/page.tsx
+++ b/src/app/viewing/reservation/[id]/confirm/page.tsx
@@ -2,6 +2,8 @@
 
 import { useParams, useRouter } from "next/navigation";
 
+import { useState } from "react";
+
 import { useViewingScheduleStore } from "@/stores/useViewingScheduleStore";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -21,6 +23,7 @@ const ViewingConfirmPage = () => {
   const { id } = useParams() as { id: string };
   const router = useRouter();
   const queryClient = useQueryClient();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { data: summaryList, isLoading } = usePropertyList({ view: "SUMMARY" });
   const { getSchedule, reset } = useViewingScheduleStore();
@@ -121,18 +124,27 @@ const ViewingConfirmPage = () => {
 
       <BottomActionBar
         label="뷰잉 예약 확정"
+        disabled={isSubmitting}
         onClick={async () => {
-          await submitViewingReservation({
-            propertyId: Number(id),
-            date: selectedSchedule.date!,
-            time: selectedSchedule.time,
-          });
-          reset(id);
+          if (isSubmitting) return;
+          setIsSubmitting(true);
 
-          await queryClient.invalidateQueries({
-            queryKey: ["myViewingList"],
-          });
-          router.push(`/viewing/reservation/${id}/complete`);
+          try {
+            await submitViewingReservation({
+              propertyId: Number(id),
+              date: selectedSchedule.date!,
+              time: selectedSchedule.time,
+            });
+            reset(id);
+            await queryClient.invalidateQueries({
+              queryKey: ["myViewingList"],
+            });
+            router.push(`/viewing/reservation/${id}/complete`);
+          } catch (err) {
+            console.error(err);
+          } finally {
+            setIsSubmitting(false);
+          }
         }}
       />
     </div>

--- a/src/components/home/ListingList.tsx
+++ b/src/components/home/ListingList.tsx
@@ -163,7 +163,7 @@ const ListingList = ({ fallbackSuburb }: { fallbackSuburb: string | null }) => {
         </div>
       ) : (
         <div className="flex flex-1 flex-col">
-          {properties.map(p => (
+          {[...properties].reverse().map(p => (
             <ListingCard
               key={p.id}
               id={p.id}

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -1,5 +1,11 @@
+"use client";
+
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+
+import { useEffect, useState } from "react";
+
+import ReservationTooltip from "@/components/reservation/ReservationTooltip";
 
 import WishListIcon from "@/public/svgs/common/heart-outline-icon.svg";
 import HomeIcon from "@/public/svgs/common/home-icon.svg";
@@ -15,6 +21,19 @@ const tabs = [
 
 const TabBar = () => {
   const pathname = usePathname();
+  const [showViewingTooltip, setShowViewingTooltip] = useState(false);
+
+  useEffect(() => {
+    const shouldShow = sessionStorage.getItem("showViewingTooltip");
+    if (shouldShow === "true") {
+      setShowViewingTooltip(true);
+      sessionStorage.removeItem("showViewingTooltip");
+
+      setTimeout(() => {
+        setShowViewingTooltip(false);
+      }, 6000);
+    }
+  }, []);
 
   return (
     <nav className="fixed bottom-0 left-1/2 z-20 max-w-[480px] min-w-[375px] -translate-x-1/2 border-t border-gray-200 bg-white py-[6px]">
@@ -26,8 +45,12 @@ const TabBar = () => {
           return (
             <li
               key={href}
-              className="flex h-[49px] w-1/4 items-center justify-center text-center"
+              className="relative flex h-[49px] w-1/4 items-center justify-center text-center"
             >
+              {href === "/home" && showViewingTooltip && (
+                <ReservationTooltip message="방금 예약한 뷰잉을 확인할 수 있어요" />
+              )}
+
               <Link href={href}>
                 <div
                   className={`text-cap1-med flex flex-col items-center gap-1 tracking-normal ${colorClass}`}

--- a/src/components/listings/BottomSheet.tsx
+++ b/src/components/listings/BottomSheet.tsx
@@ -2,6 +2,8 @@ import { useParams, useRouter } from "next/navigation";
 
 import { useEffect, useState } from "react";
 
+import { useDeleteProperty } from "@/hooks/property/useProperty";
+
 import Divider from "@/components/common/Divider";
 
 interface BottomSheetProps {
@@ -19,24 +21,36 @@ const BottomSheet = ({
   const router = useRouter();
 
   const [isOpen, setIsOpen] = useState(false);
+  const { mutate: deleteProperty } = useDeleteProperty(Number(id));
 
   useEffect(() => {
     setIsOpen(true);
   }, []);
 
-  const handleClose = () => {
+  const closeSheet = (callback?: () => void) => {
     setIsOpen(false);
     setTimeout(() => {
       onClose();
+      callback?.();
     }, 300);
   };
 
+  const handleEditClick = () => {
+    router.push(`/listings/${id}/edit`);
+  };
+
   const handleHideClick = () => {
-    setIsOpen(false);
-    setTimeout(() => {
-      onClose(); // 바텀시트 닫고
-      onHideClick(); // 모달 띄우기
-    }, 300);
+    closeSheet(onHideClick);
+  };
+
+  const handleDeleteClick = () => {
+    closeSheet(() => {
+      deleteProperty(undefined, {
+        onSuccess: () => {
+          router.replace("/mypage/listings");
+        },
+      });
+    });
   };
 
   return (
@@ -44,7 +58,7 @@ const BottomSheet = ({
       {/* 오버레이 */}
       <div
         className="fixed inset-0 z-[100] bg-gray-800 opacity-60"
-        onClick={handleClose}
+        onClick={() => closeSheet()}
       />
 
       {/* 바텀시트 */}
@@ -61,7 +75,7 @@ const BottomSheet = ({
         <Divider className="my-1" />
         <div
           className="text-body1-sb w-full cursor-pointer py-2 text-center text-gray-900"
-          onClick={() => router.push(`/listings/${id}/edit`)}
+          onClick={handleEditClick}
         >
           매물정보 수정
         </div>
@@ -75,7 +89,7 @@ const BottomSheet = ({
         <Divider className="my-1" />
         <div
           className="text-body1-sb text-red w-full cursor-pointer py-2 text-center"
-          onClick={handleClose}
+          onClick={handleDeleteClick}
         >
           삭제
         </div>

--- a/src/components/mypage/ListingHideModal.tsx
+++ b/src/components/mypage/ListingHideModal.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from "next/navigation";
 
 import { usePatchDisplayStatus } from "@/hooks/property/useProperty";
-import { useCancelViewing } from "@/hooks/viewing/useViewing";
+import { useCancelAllViewings } from "@/hooks/viewing/useViewing";
 
 import AlertModal from "@/components/common/AlertModal";
 
@@ -9,30 +9,20 @@ interface ListingHideModalProps {
   onClose: () => void;
   listingId: number;
   kind: "SHARE" | "RENT";
-  viewingIds: number[];
 }
 
 const ListingHideModal = ({
   onClose,
   listingId,
   kind,
-  viewingIds,
 }: ListingHideModalProps) => {
   const { mutate: patchDisplayStatus } = usePatchDisplayStatus(listingId);
-  const { mutateAsync: cancelViewing } = useCancelViewing();
+  const { mutateAsync: cancelAllViewings } = useCancelAllViewings();
   const router = useRouter();
 
   const handleCancelAndHide = async () => {
     try {
-      await Promise.all(
-        viewingIds.map(viewingId =>
-          cancelViewing({
-            viewingId,
-            optionItemId: 100,
-            reason: "매물 숨김 처리로 인한 예약 취소",
-          }),
-        ),
-      );
+      await cancelAllViewings(listingId);
 
       patchDisplayStatus(
         { displayStatus: "INACTIVE", jsonDiscriminator: kind },
@@ -44,7 +34,7 @@ const ListingHideModal = ({
         },
       );
     } catch (err) {
-      console.error("예약 취소 실패", err);
+      console.error("일괄 예약 취소 실패", err);
     }
   };
 

--- a/src/components/reservation/ReservationTooltip.tsx
+++ b/src/components/reservation/ReservationTooltip.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+interface ReservationTooltipProps {
+  message: string;
+}
+
+const ReservationTooltip = ({ message }: ReservationTooltipProps) => {
+  return (
+    <div className="absolute -top-16 left-[143px] flex flex-col items-center">
+      <div className="text-cap1-med rounded bg-gray-800 p-3 whitespace-nowrap text-gray-300">
+        {message}
+      </div>
+      <div className="h-0 w-0 border-x-[9px] border-t-[15px] border-x-transparent border-t-gray-800" />
+    </div>
+  );
+};
+
+export default ReservationTooltip;

--- a/src/components/viewings/ViewingCanceledSection.tsx
+++ b/src/components/viewings/ViewingCanceledSection.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { ViewingPropertyItem } from "@/types/viewing";
 
+import ContentWrapper from "../layout/ContentWrapper";
 import CancelReasonModal from "./CancelReasonModal";
 import ViewingEmptyMessage from "./ViewingEmptyMessage";
 import ViewingManageCard from "./ViewingManageCard";
@@ -19,7 +20,7 @@ const ViewingCanceledSection = ({ data }: ViewingCanceledSectionProps) => {
   }
 
   return (
-    <>
+    <ContentWrapper className="mb-6 flex flex-col" bottomOffset={62}>
       <ul className="mt-4 flex flex-col gap-4">
         {data.map(item => (
           <li key={item.id}>
@@ -41,7 +42,7 @@ const ViewingCanceledSection = ({ data }: ViewingCanceledSectionProps) => {
           viewingId={selectedItem.id}
         />
       )}
-    </>
+    </ContentWrapper>
   );
 };
 

--- a/src/components/viewings/ViewingCompletedSection.tsx
+++ b/src/components/viewings/ViewingCompletedSection.tsx
@@ -1,5 +1,6 @@
 import { ViewingPropertyItem } from "@/types/viewing";
 
+import ContentWrapper from "../layout/ContentWrapper";
 import ViewingEmptyMessage from "./ViewingEmptyMessage";
 import ViewingManageCard from "./ViewingManageCard";
 
@@ -13,7 +14,7 @@ const ViewingCompletedSection = ({ data }: ViewingCompletedSectionProps) => {
   }
 
   return (
-    <ul className="mt-4 flex flex-col gap-4">
+    <ContentWrapper className="mt-4 mb-6 flex flex-col gap-4" bottomOffset={62}>
       {data.map(item => {
         return (
           <li key={item.id}>
@@ -25,7 +26,7 @@ const ViewingCompletedSection = ({ data }: ViewingCompletedSectionProps) => {
           </li>
         );
       })}
-    </ul>
+    </ContentWrapper>
   );
 };
 

--- a/src/components/viewings/ViewingConfirmedSection.tsx
+++ b/src/components/viewings/ViewingConfirmedSection.tsx
@@ -65,7 +65,10 @@ const ViewingConfirmedSection = ({ data }: ViewingConfirmedSectionProps) => {
               const userType: "host" | "guest" = isGuest ? "guest" : "host";
 
               return (
-                <div key={item.property.id} className="flex flex-col gap-4">
+                <div
+                  key={`item-${dday}-${item.id}`}
+                  className="flex flex-col gap-4"
+                >
                   <ViewingManageCard
                     id={item.id}
                     viewingItem={item}

--- a/src/hooks/listings/useListing.ts
+++ b/src/hooks/listings/useListing.ts
@@ -1,9 +1,0 @@
-// import { getListingDetail } from "@/api/listing";
-import { useQuery } from "@tanstack/react-query";
-
-export const useListing = (listingId: string) => {
-  return useQuery({
-    queryKey: ["listing", listingId],
-    // queryFn: () => getListingDetail(listingId),
-  });
-};

--- a/src/hooks/viewing/useViewing.ts
+++ b/src/hooks/viewing/useViewing.ts
@@ -104,10 +104,13 @@ export const usePutViewingPropertyNotes = () => {
   });
 };
 
-export const useViewingGuests = (propertyId: number) => {
+export const useViewingGuests = (
+  propertyId: number,
+  status?: ViewingStatus[],
+) => {
   return useQuery({
-    queryKey: ["viewingGuests", propertyId],
-    queryFn: () => fetchViewingGuests(propertyId),
+    queryKey: ["viewingGuests", propertyId, status],
+    queryFn: () => fetchViewingGuests(propertyId, status),
     enabled: !!propertyId,
     staleTime: 0,
   });

--- a/src/hooks/viewing/useViewing.ts
+++ b/src/hooks/viewing/useViewing.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
+  cancelAllViewings,
   cancelViewing,
   fetchViewingGuests,
   getMyViewingDates,
@@ -73,6 +74,12 @@ export const useCancelViewing = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["myViewingList"] });
     },
+  });
+};
+
+export const useCancelAllViewings = () => {
+  return useMutation({
+    mutationFn: (propertyId: number) => cancelAllViewings(propertyId),
   });
 };
 


### PR DESCRIPTION
### 🔥 작업 내용
- 상세 페이지 지도 공개 조건 로직 개선
  - 매물의 호스트이거나, 해당 매물에 대한 뷰잉 예약자일 경우 지도가 노출되도록 조건을 추가하였습니다.
  - <img width="324" height="224" alt="지도 공개 조건" src="https://github.com/user-attachments/assets/79d32f5e-798e-44c4-956e-05c24ad5b1c9" />

- 뷰잉 예약 툴팁 기능 추가
  - 뷰잉 예약 완료 시, 사용자에게 안내 메시지를 툴팁 형태로 제공하도록 구현하였습니다.
  - 해당 툴팁은 sessionStorage('hasSeenViewingTooltip') 기반으로, 한 번만 노출되도록 제한하였습니다.

- 뷰잉 일괄 취소 API 연동
  - 기존에는 예약된 뷰잉 ID 리스트를 순회하며 개별 취소 처리했으나, 백엔드에서 일괄 취소용 API (/cancel-all)가 제공해주셔서 해당 방식으로 개선하였습니다.

- 게스트 목록 조회 시 파라미터 개선
  - Viewing 상태별로 데이터를 요청할 수 있도록 status 파라미터 형식을 적용하였습니다.

- 홈 매물 리스트 렌더링 순서 조정
  - 매물 목록이 최신순으로 보이도록 데이터를 reverse() 처리하여 렌더링 순서를 조정하였습니다.

- 뷰잉 관리 탭 레이아웃 구조 개선
  - ContentWrapper를 활용하여 하단 여백을 추가하였습니다.


### 📸 작업 내역 스크린샷
<img width="374" height="798" alt="스크린샷 2025-07-28 오전 12 02 31" src="https://github.com/user-attachments/assets/8801b212-db6b-4974-ace8-99f3b0dc7b23" />

### 🔗 이슈
- #79 
