### PR TITLE
✨ Feat: 상세페이지 스켈레톤 UI 추가

### DIFF
--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -22,6 +22,7 @@ import DetailTabs from "@/components/listings/DetailTabs";
 import DropDownMenu from "@/components/listings/DropDownMenu";
 import ImageSlider from "@/components/listings/ImageSlider";
 import ListingHideModal from "@/components/mypage/ListingHideModal";
+import ListingDetailLoadingSkeleton from "@/components/skeleton/listingsDetail/ListingDetailLoadingSkeleton";
 
 import CertificatedIcon from "@/public/svgs/common/certificated-icon.svg";
 import HeartFilledIcon from "@/public/svgs/common/heart-filled-icon.svg";
@@ -103,8 +104,11 @@ const ListingDetailPage = () => {
       },
     );
   };
+  if (isLoading) {
+    return <ListingDetailLoadingSkeleton mode={mode} />;
+  }
+  if (isError || !data) return null;
 
-  if (isLoading || isError || !data) return null;
   return (
     <>
       <div className="flex min-h-screen flex-col pb-16">

--- a/src/components/listings/ContractInfo.tsx
+++ b/src/components/listings/ContractInfo.tsx
@@ -7,7 +7,10 @@ import { CATEGORY_OPTIONS } from "@/constants/propertyCategory";
 
 import { Property } from "@/types/property";
 
-const ContractInfo = ({ data }: { data: Property }) => {
+import ContractInfoSkeleton from "../skeleton/listingsDetail/ContractInfoSkeleton";
+
+const ContractInfo = ({ data }: { data?: Property }) => {
+  if (!data) return <ContractInfoSkeleton />;
   const includedOptionIds =
     data.optionItems?.map(item => item.optionItemId) ?? [];
 

--- a/src/components/listings/DetailTabs.tsx
+++ b/src/components/listings/DetailTabs.tsx
@@ -8,7 +8,7 @@ import { Property } from "@/types/property";
 
 interface DetailTabsProps {
   listingId: string;
-  data: Property;
+  data?: Property;
 }
 
 const DetailTabs = ({ listingId, data }: DetailTabsProps) => {
@@ -16,7 +16,6 @@ const DetailTabs = ({ listingId, data }: DetailTabsProps) => {
     useState<(typeof listingDetailTabs)[number]["key"]>("detail");
 
   const activeTab = listingDetailTabs.find(tab => tab.key === activeKey);
-  const ActiveComponent = activeTab?.Component;
 
   return (
     <>
@@ -37,11 +36,11 @@ const DetailTabs = ({ listingId, data }: DetailTabsProps) => {
         ))}
       </div>
 
-      <div>
-        {ActiveComponent && (
-          <ActiveComponent listingId={listingId} data={data} />
-        )}
-      </div>
+      {activeTab && (
+        <div key={activeKey}>
+          <activeTab.Component listingId={listingId} data={data} />
+        </div>
+      )}
     </>
   );
 };

--- a/src/components/listings/ListingDetail.tsx
+++ b/src/components/listings/ListingDetail.tsx
@@ -1,14 +1,17 @@
 import { Property } from "@/types/property";
 
+import ListingDetailSkeleton from "../skeleton/listingsDetail/ListingDetailSkeleton";
 import RentDetail from "./RentDetail";
 import ShareDetail from "./ShareDetail";
 
 interface ListingDetailProps {
   listingId: string;
-  data: Property;
+  data?: Property;
 }
 
 const ListingDetail = ({ listingId, data }: ListingDetailProps) => {
+  if (!data) return <ListingDetailSkeleton />;
+
   if (data?.kind === "RENT") {
     return <RentDetail listingId={listingId} data={data} />;
   }

--- a/src/components/listings/MoveInCondition.tsx
+++ b/src/components/listings/MoveInCondition.tsx
@@ -14,9 +14,11 @@ import { GENDER_PREFERENCE_LABEL_MAP } from "@/constants/gender-options";
 
 import { Property } from "@/types/property";
 
+import MoveInConditionSkeleton from "../skeleton/listingsDetail/MoveInConditionSkeleton";
 import ExtraConditions from "./ExtraConditions";
 
-const MoveInCondition = ({ data }: { data: Property }) => {
+const MoveInCondition = ({ data }: { data?: Property }) => {
+  if (!data) return <MoveInConditionSkeleton />;
   const moveInTexts = [
     data.moveInInfo.immediate && "즉시 입주 가능",
     data.moveInInfo.negotiable && "입주일자 협의 가능",

--- a/src/components/skeleton/listingsDetail/ContractInfoSkeleton.tsx
+++ b/src/components/skeleton/listingsDetail/ContractInfoSkeleton.tsx
@@ -1,0 +1,63 @@
+import Label from "@/components/listings/shared/Label";
+import Section from "@/components/listings/shared/Section";
+
+const ContractInfoSkeleton = () => {
+  return (
+    <div className="bg-gray-0 flex flex-col py-3">
+      {/* 빌 포함 항목 */}
+      <Section>
+        <div className="flex flex-col gap-4 px-4 py-3">
+          <Label>빌 포함 항목</Label>
+          <div className="flex flex-wrap items-center gap-2">
+            {[...Array(6)].flatMap((_, idx) => {
+              const item = (
+                <div
+                  key={`item-${idx}`}
+                  className="h-[21px] w-[37px] animate-pulse rounded bg-gray-200"
+                />
+              );
+              const divider =
+                idx < 5 ? (
+                  <span
+                    key={`divider-${idx}`}
+                    className="h-3 w-px bg-gray-300"
+                  />
+                ) : null;
+
+              return [item, divider];
+            })}
+          </div>
+          <div className="text-body2-med bg-gray-0 h-[33px] rounded border border-gray-400 px-3 py-1.5 text-gray-600">
+            주차비는 주/20$ 입니다
+          </div>
+        </div>
+      </Section>
+
+      {/* 디파짓 */}
+      <Section>
+        <div className="flex flex-col gap-3 px-4 py-3">
+          <div className="flex items-center justify-between">
+            <Label>디파짓</Label>
+            <div className="text-body1-med text-gray-700">$/주</div>
+          </div>
+          <div className="h-4 w-[218px] animate-pulse rounded bg-gray-200" />
+        </div>
+      </Section>
+
+      {/* 계약 형태 설명 */}
+      <Section withDivider={false}>
+        <div className="flex flex-col gap-3 px-4 py-3">
+          <Label>계약 형태 설명</Label>
+          <div className="flex flex-col gap-2">
+            <div className="text-body2-med bg-gray-0 h-[33px] rounded border border-gray-400 px-3 py-1.5 text-gray-600">
+              월 단위로 계약합니다
+            </div>
+            <div className="h-4 w-[135px] animate-pulse rounded bg-gray-200" />
+          </div>
+        </div>
+      </Section>
+    </div>
+  );
+};
+
+export default ContractInfoSkeleton;

--- a/src/components/skeleton/listingsDetail/ListingContentSkeleton.tsx
+++ b/src/components/skeleton/listingsDetail/ListingContentSkeleton.tsx
@@ -1,0 +1,41 @@
+const ListingContentSkeleton = () => {
+  return (
+    <div className="pointer-events-none">
+      {/* 이미지 영역 */}
+      <div className="h-[375px] w-[375px] animate-pulse bg-gray-200" />
+
+      {/* 프로필 영역 */}
+      <div className="flex items-center gap-[14px] border-b border-gray-200 px-4 py-3">
+        <div className="h-12 w-12 animate-pulse rounded-full bg-gray-200" />
+        <div className="h-[22px] w-15 animate-pulse rounded bg-gray-200" />
+      </div>
+
+      {/* 상단 요약 */}
+      <div className="flex justify-between px-4 py-7">
+        <div className="flex flex-col gap-2">
+          <div className="flex gap-2">
+            <div className="h-7.5 w-25 animate-pulse rounded bg-gray-200" />
+            <div className="h-7.5 w-[57px] animate-pulse rounded-[100px] bg-gray-200" />
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="h-[22px] w-[30px] animate-pulse rounded bg-gray-200" />
+            <span className="h-3 w-px bg-gray-200" />
+            <div className="h-[22px] w-[60px] animate-pulse rounded bg-gray-200" />
+          </div>
+        </div>
+        <div className="flex h-[70px] flex-col items-end gap-4">
+          <div className="flex items-center gap-1">
+            <div className="h-4 w-[34px] animate-pulse rounded bg-gray-200" />
+            <div className="h-[18px] w-[18px] animate-pulse rounded bg-gray-200" />
+          </div>
+          <div className="flex flex-col items-end gap-1">
+            <div className="h-4 w-[104px] animate-pulse rounded bg-gray-200" />
+            <div className="h-4 w-[70px] animate-pulse rounded bg-gray-200" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ListingContentSkeleton;

--- a/src/components/skeleton/listingsDetail/ListingDetailLoadingSkeleton.tsx
+++ b/src/components/skeleton/listingsDetail/ListingDetailLoadingSkeleton.tsx
@@ -1,0 +1,44 @@
+import BottomActionBar from "@/components/common/BottomActionBar";
+import BackHeader from "@/components/layout/header/BackHeader";
+import DetailTabs from "@/components/listings/DetailTabs";
+
+import ListingContentSkeleton from "./ListingContentSkeleton";
+
+const ListingDetailLoadingSkeleton = ({ mode }: { mode?: string | null }) => {
+  const isConfirmMode = mode === "confirm";
+  const isEditMode = mode === "edit";
+
+  return (
+    <>
+      <BackHeader
+        hideBackIcon={isConfirmMode}
+        rightIcon={isEditMode ? "more" : "report"}
+      />
+      <div className="flex min-h-screen flex-col pb-16">
+        <ListingContentSkeleton />
+        <DetailTabs data={undefined} listingId="loading" />
+        <div className="mt-6 mb-15">
+          <div className="flex flex-col gap-3 px-4 py-8">
+            <span className="text-heading3 text-gray-900">위치</span>
+            <div className="flex h-[343px] w-[343px] items-center justify-center">
+              <span className="text-heading3 text-gray-600">
+                상세 주소는 뷰잉 예약 후 확인 가능합니다.
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <BottomActionBar
+        label={
+          isConfirmMode
+            ? "홈으로 이동"
+            : isEditMode
+              ? "거래한 게스트 입력하기"
+              : "뷰잉 예약하기"
+        }
+      />
+    </>
+  );
+};
+
+export default ListingDetailLoadingSkeleton;

--- a/src/components/skeleton/listingsDetail/ListingDetailSkeleton.tsx
+++ b/src/components/skeleton/listingsDetail/ListingDetailSkeleton.tsx
@@ -1,0 +1,73 @@
+import Section from "@/components/listings/shared/Section";
+
+const ListingDetailSkeleton = () => {
+  return (
+    <div className="bg-gray-0 flex flex-col py-3">
+      {/* 매물 유형 */}
+      <div className="px-4 py-3">
+        <div className="h-5 w-24 animate-pulse rounded bg-gray-200" />
+      </div>
+
+      {/* 쉐어 인원 & 층수 카드 */}
+      <Section>
+        <div className="flex w-full py-3">
+          {/* 쉐어 인원 */}
+          <div className="flex w-1/2 flex-col gap-2 px-4">
+            <div className="h-5 w-20 animate-pulse rounded bg-gray-200" />
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <div className="h-5 w-5 animate-pulse rounded-full bg-gray-300" />
+                <div className="h-4 w-28 animate-pulse rounded bg-gray-200" />
+              </div>
+            ))}
+          </div>
+
+          {/* 층수 */}
+          <div className="flex w-1/2 flex-col gap-2 px-4">
+            <div className="h-5 w-20 animate-pulse rounded bg-gray-200" />
+            {[...Array(2)].map((_, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <div className="h-5 w-5 animate-pulse rounded-full bg-gray-300" />
+                <div className="h-4 w-28 animate-pulse rounded bg-gray-200" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </Section>
+
+      {/* 주차 */}
+      <Section>
+        <div className="flex flex-col gap-2 px-4 py-3">
+          <div className="h-5 w-24 animate-pulse rounded bg-gray-200" />
+          <div className="h-4 w-40 animate-pulse rounded bg-gray-100" />
+        </div>
+      </Section>
+
+      {/* 가구 포함 */}
+      <Section>
+        <div className="flex flex-col gap-2 px-4 py-3">
+          <div className="h-5 w-24 animate-pulse rounded bg-gray-200" />
+          <div className="flex flex-wrap gap-2">
+            {[...Array(3)].map((_, i) => (
+              <div
+                key={i}
+                className="h-4 w-20 animate-pulse rounded bg-gray-100"
+              />
+            ))}
+          </div>
+        </div>
+      </Section>
+
+      {/* 호스트 소개 */}
+      <Section withDivider={false}>
+        <div className="flex flex-col gap-2 px-4 py-3">
+          <div className="h-5 w-24 animate-pulse rounded bg-gray-200" />
+          <div className="h-4 w-64 animate-pulse rounded bg-gray-100" />
+          <div className="h-4 w-[70%] animate-pulse rounded bg-gray-100" />
+        </div>
+      </Section>
+    </div>
+  );
+};
+
+export default ListingDetailSkeleton;

--- a/src/components/skeleton/listingsDetail/MoveInConditionSkeleton.tsx
+++ b/src/components/skeleton/listingsDetail/MoveInConditionSkeleton.tsx
@@ -1,0 +1,69 @@
+import Section from "@/components/listings/shared/Section";
+
+const MoveInConditionSkeleton = () => {
+  const conditions = [
+    "주방 사용 가능",
+    "외부인 방문 협의",
+    "흡연자 불가능",
+    "반려동물 가능",
+  ];
+
+  return (
+    <div className="bg-gray-0 flex flex-col py-3">
+      {/* 거주 가능 조건 */}
+      <Section>
+        <div className="flex items-center justify-between px-4 py-3">
+          <span className="text-body1-sb text-gray-900">거주 가능 조건</span>
+          <div className="flex flex-col items-end gap-1">
+            <div className="h-[21px] w-[105px] animate-pulse rounded bg-gray-200" />
+            <div className="h-[21px] w-[66px] animate-pulse rounded bg-gray-200" />
+          </div>
+        </div>
+      </Section>
+
+      {/* 노티스 / 최소 거주 기간 */}
+      <Section>
+        <div className="flex w-full py-3">
+          <div className="flex w-1/2 flex-col gap-2 px-4">
+            <span className="text-body1-sb text-gray-900">노티스</span>
+            <div className="h-[21px] w-[105px] animate-pulse rounded bg-gray-200" />
+          </div>
+          <div className="flex w-1/2 flex-col gap-2 px-4">
+            <span className="text-body1-sb text-gray-900">최소 거주 기간</span>
+            <div className="h-[21px] w-[105px] animate-pulse rounded bg-gray-200" />
+          </div>
+        </div>
+      </Section>
+
+      {/* 입주 가능일 */}
+      <Section>
+        <div className="flex flex-col gap-2 px-4 py-3">
+          <span className="text-body1-sb text-gray-900">입주 가능일</span>
+          <div className="h-[21px] w-[298px] animate-pulse rounded bg-gray-200" />
+        </div>
+      </Section>
+
+      {/* 추가 고려사항 */}
+      <Section>
+        <div className="flex flex-col gap-3 px-4 py-3">
+          <div className="flex items-center justify-between">
+            <span className="text-body1-sb text-gray-900">추가 고려사항</span>
+            <span className="text-cap1-med text-gray-600">조건 협의 가능</span>
+          </div>
+          <div className="grid w-full grid-cols-2 gap-2">
+            {conditions.map((item, idx) => (
+              <div
+                key={idx}
+                className="text-body2-med flex items-center justify-center rounded bg-gray-200 px-3 py-[7.5px] text-gray-700"
+              >
+                {item}
+              </div>
+            ))}
+          </div>
+        </div>
+      </Section>
+    </div>
+  );
+};
+
+export default MoveInConditionSkeleton;

--- a/src/constants/listing-detail-tabs.ts
+++ b/src/constants/listing-detail-tabs.ts
@@ -7,7 +7,7 @@ import { Property } from "@/types/property";
 type TabItem = {
   key: string;
   label: string;
-  Component: React.ComponentType<{ listingId: string; data: Property }>;
+  Component: React.ComponentType<{ listingId: string; data?: Property }>;
 };
 
 export const listingDetailTabs: readonly TabItem[] = [


### PR DESCRIPTION
### 🔥 작업 내용
- 매물 상세페이지에 스켈레톤 UI 추가했습니다. 상세페이지 스켈레톤이 저번 PR에 안올라가서 나눠 올립니다..

### 🤔 추후 작업 사항
- 매물 상세 탭 스켈레톤은 디자인 변동 예정입니다 (ListingDetailSkeleton.tsx) - 피그마 수정본 나오고 작업 가능

### 📸 작업 내역 스크린샷
- 상세페이지 진입 시

https://github.com/user-attachments/assets/7e81add4-f080-43ae-a6a6-fadb10a9b3fb


- 상세페이지에서 다른 탭 선택 시 

https://github.com/user-attachments/assets/6d05e1d7-bc21-4240-9c14-b269f6a8b23d


### 🔗 이슈
- #82 
