### PR TITLE
✨ Feat: 뷰잉이 있는 매물일 경우 매물 삭제 요청 시 AlertModal 추가

### DIFF
--- a/src/apis/property.ts
+++ b/src/apis/property.ts
@@ -97,9 +97,23 @@ export const completeTrade = async ({
   viewingId?: number;
   dealWithOutsider: boolean;
 }) => {
+  const params: {
+    dealWithOutsider: boolean;
+    viewingId?: number;
+  } = {
+    dealWithOutsider,
+  };
+
+  if (viewingId !== undefined) {
+    params.viewingId = viewingId;
+  }
+
   const res = await axiosInstance.post(
-    `/api/v1/properties/${propertyId}/complete?viewingId=${viewingId}?dealWithOutsider=${dealWithOutsider}`,
+    `/api/v1/properties/${propertyId}/complete`,
+    null,
+    { params },
   );
+
   return res.data.data;
 };
 

--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -21,6 +21,7 @@ import BottomSheet from "@/components/listings/BottomSheet";
 import DetailTabs from "@/components/listings/DetailTabs";
 import DropDownMenu from "@/components/listings/DropDownMenu";
 import ImageSlider from "@/components/listings/ImageSlider";
+import ListingDeleteModal from "@/components/mypage/ListingDeleteModal";
 import ListingHideModal from "@/components/mypage/ListingHideModal";
 import ListingDetailLoadingSkeleton from "@/components/skeleton/listingsDetail/ListingDetailLoadingSkeleton";
 
@@ -41,7 +42,8 @@ const ListingDetailPage = () => {
   const isEditMode = mode === "edit";
 
   const [isClicked, setIsClicked] = useState(false);
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [showHideModal, setShowHideModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   const { data, isLoading, isError, refetch } =
     usePropertyDetailList(listingId);
@@ -90,7 +92,7 @@ const ListingDetailPage = () => {
     const isActive = data.displayStatus === "ACTIVE";
 
     if (isActive && hasGuests) {
-      setIsModalOpen(true);
+      setShowHideModal(true);
       return;
     }
 
@@ -285,15 +287,21 @@ const ListingDetailPage = () => {
           onClose={() => setIsClicked(false)}
           onHideClick={handleHideClick}
           displayStatus={data.displayStatus as "ACTIVE" | "INACTIVE"}
+          viewingCount={viewingGuests?.length ?? 0}
+          onShowDeleteModal={() => setShowDeleteModal(true)}
         />
       )}
 
-      {isModalOpen && viewingGuests && (
+      {showHideModal && viewingGuests && (
         <ListingHideModal
           listingId={data.id}
           kind={data.kind}
-          onClose={() => setIsModalOpen(false)}
+          onClose={() => setShowHideModal(false)}
         />
+      )}
+
+      {showDeleteModal && (
+        <ListingDeleteModal onClose={() => setShowDeleteModal(false)} />
       )}
     </>
   );

--- a/src/components/home/ViewingSection.tsx
+++ b/src/components/home/ViewingSection.tsx
@@ -81,8 +81,8 @@ const ViewingSection = () => {
                 <ViewingBox
                   date={getDisplayDate(day)}
                   time={day.format("A h:mm")}
-                  profileImg={viewing.propertyThumbnailUrl || ""}
-                  roomImg={"/svgs/common/room-img.svg"}
+                  profileImg={viewing.counterpartImageUrl || ""}
+                  roomImg={viewing.propertyThumbnailUrl || ""}
                 />
               </div>
             );

--- a/src/components/listings/BottomSheet.tsx
+++ b/src/components/listings/BottomSheet.tsx
@@ -10,12 +10,16 @@ interface BottomSheetProps {
   onClose: () => void;
   onHideClick: () => void;
   displayStatus?: "ACTIVE" | "INACTIVE";
+  viewingCount: number;
+  onShowDeleteModal: () => void;
 }
 
 const BottomSheet = ({
   onClose,
   onHideClick,
   displayStatus,
+  viewingCount,
+  onShowDeleteModal,
 }: BottomSheetProps) => {
   const { id } = useParams();
   const router = useRouter();
@@ -44,6 +48,13 @@ const BottomSheet = ({
   };
 
   const handleDeleteClick = () => {
+    if (displayStatus === "ACTIVE" && viewingCount > 0) {
+      closeSheet(() => {
+        onShowDeleteModal();
+      });
+      return;
+    }
+
     closeSheet(() => {
       deleteProperty(undefined, {
         onSuccess: () => {
@@ -68,27 +79,27 @@ const BottomSheet = ({
         }`}
         onClick={e => e.stopPropagation()}
       >
-        <div className="flex justify-center pb-2">
+        <div className="flex justify-center pb-4">
           <div className="h-1 w-[53px] rounded-[50px] bg-gray-500" />
         </div>
 
         <Divider className="my-1" />
         <div
-          className="text-body1-sb w-full cursor-pointer py-2 text-center text-gray-900"
+          className="text-body1-sb w-full cursor-pointer py-4 text-center text-gray-900"
           onClick={handleEditClick}
         >
           매물정보 수정
         </div>
         <Divider className="my-1" />
         <div
-          className="text-body1-sb w-full cursor-pointer py-2 text-center text-gray-900"
+          className="text-body1-sb w-full cursor-pointer py-4 text-center text-gray-900"
           onClick={handleHideClick}
         >
           {displayStatus === "ACTIVE" ? "숨기기" : "숨기기 취소"}
         </div>
         <Divider className="my-1" />
         <div
-          className="text-body1-sb text-red w-full cursor-pointer py-2 text-center"
+          className="text-body1-sb text-red w-full cursor-pointer py-4 text-center"
           onClick={handleDeleteClick}
         >
           삭제

--- a/src/components/listings/BottomSheet.tsx
+++ b/src/components/listings/BottomSheet.tsx
@@ -55,12 +55,12 @@ const BottomSheet = ({
       return;
     }
 
-    closeSheet(() => {
-      deleteProperty(undefined, {
-        onSuccess: () => {
+    deleteProperty(undefined, {
+      onSuccess: () => {
+        closeSheet(() => {
           router.replace("/mypage/listings");
-        },
-      });
+        });
+      },
     });
   };
 

--- a/src/components/mypage/ListingDeleteModal.tsx
+++ b/src/components/mypage/ListingDeleteModal.tsx
@@ -1,0 +1,20 @@
+import AlertModal from "@/components/common/AlertModal";
+
+interface ListingDeleteModalProps {
+  onClose: () => void;
+}
+
+const ListingDeleteModal = ({ onClose }: ListingDeleteModalProps) => {
+  return (
+    <AlertModal
+      title="뷰잉 예약된 매물은 삭제할 수 없어요"
+      description={[
+        "뷰잉관리에서 뷰잉을 취소한 후,",
+        "예약된 뷰잉이 없는 상태에서 삭제를 진행해주세요",
+      ]}
+      onClose={onClose}
+    />
+  );
+};
+
+export default ListingDeleteModal;


### PR DESCRIPTION
### 🔥 작업 내용
- 뷰잉이 있는 매물의 경우, 매물 삭제 시 AlertModal이 표시되도록 처리했습니다. 이를 위해 바텀시트에서 viewingCount 값을 전달하도록 구현했습니다.
- 홈 화면의 뷰잉 박스에서 변수명이 잘못되어 있던 부분을 수정했습니다.
- 매물 거래 완료 API 요청에서 오타를 수정하고, 관련 로직을 리팩토링했습니다.

### 📸 작업 내역 스크린샷
<img width="376" height="633" alt="스크린샷 2025-07-30 오전 12 52 12" src="https://github.com/user-attachments/assets/9bbed5a9-0932-42a8-9047-f98d84b175da" />

### 🔗 이슈
- #87 
