### PR TITLE
✨ Feat: 숨김 매물 상세 페이지 접근 시 토스트 추가

### DIFF
--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -295,7 +295,7 @@ const ListingDetailPage = () => {
         />
       )}
 
-      {!isConfirmMode && !isViewingMode && !isEditMode && !isLoading && (
+      {!isConfirmMode && !isViewingMode && !isEditMode && (
         <BottomActionBar
           label="뷰잉 예약하기"
           onClick={() => router.push(`/viewing/reservation/${listingId}`)}

--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
 
 import { useAuthStore } from "@/stores/useAuthStore";
+import { AxiosError } from "axios";
 
 import {
   usePatchDisplayStatus,
@@ -24,6 +25,8 @@ import ImageSlider from "@/components/listings/ImageSlider";
 import ListingDeleteModal from "@/components/mypage/ListingDeleteModal";
 import ListingHideModal from "@/components/mypage/ListingHideModal";
 import ListingDetailLoadingSkeleton from "@/components/skeleton/listingsDetail/ListingDetailLoadingSkeleton";
+
+import { PropertyErrorResponse } from "@/types/property";
 
 import CertificatedIcon from "@/public/svgs/common/certificated-icon.svg";
 import HeartFilledIcon from "@/public/svgs/common/heart-filled-icon.svg";
@@ -45,12 +48,20 @@ const ListingDetailPage = () => {
   const [showHideModal, setShowHideModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
-  const { data, isLoading, isError, refetch } =
+  const { data, isLoading, error, isError, refetch } =
     usePropertyDetailList(listingId);
-  const { data: viewingGuests } = useViewingGuests(Number(listingId), [
-    "REQUESTED",
-    "COMPLETED",
-  ]);
+
+  const isMyListing = useMemo(
+    () => data?.hostSummary?.id === Number(memberId),
+    [data, memberId],
+  );
+
+  const { data: viewingGuests } = useViewingGuests(
+    Number(listingId),
+    ["REQUESTED", "COMPLETED"],
+    !!data && isMyListing,
+  );
+
   const { mutate: toggleWish } = useToggleWish();
   const { mutate: patchDisplayStatus } = usePatchDisplayStatus(
     Number(listingId),
@@ -58,10 +69,6 @@ const ListingDetailPage = () => {
 
   const [tradeStatus, setTradeStatus] = useState(data?.tradeStatus);
 
-  const isMyListing = useMemo(
-    () => data?.hostSummary?.id === Number(memberId),
-    [data, memberId],
-  );
   const isMyReservedListing = useMemo(
     () =>
       viewingGuests?.some(guest => guest.guestId === Number(memberId)) ?? false,
@@ -106,8 +113,21 @@ const ListingDetailPage = () => {
       },
     );
   };
-  if (isLoading) {
-    return <ListingDetailLoadingSkeleton mode={mode} />;
+
+  if (
+    isLoading ||
+    (isError &&
+      (error as AxiosError<PropertyErrorResponse>)?.response?.data
+        ?.serviceCode === "PROPERTY_IS_HIDDEN")
+  ) {
+    return (
+      <ListingDetailLoadingSkeleton
+        mode={mode}
+        isError={isError}
+        error={error}
+        onHiddenProperty={() => router.back()}
+      />
+    );
   }
   if (isError || !data) return null;
 
@@ -275,7 +295,7 @@ const ListingDetailPage = () => {
         />
       )}
 
-      {!isConfirmMode && !isViewingMode && !isEditMode && (
+      {!isConfirmMode && !isViewingMode && !isEditMode && !isLoading && (
         <BottomActionBar
           label="뷰잉 예약하기"
           onClick={() => router.push(`/viewing/reservation/${listingId}`)}

--- a/src/components/skeleton/listingsDetail/ListingDetailLoadingSkeleton.tsx
+++ b/src/components/skeleton/listingsDetail/ListingDetailLoadingSkeleton.tsx
@@ -63,7 +63,7 @@ const ListingDetailLoadingSkeleton = ({
 
       {isHidden && (
         <AlertMessage
-          message="숨김 처리된 매물입니다."
+          message="숨김 처리된 매물입니다"
           className="bottom-3"
           onDone={onHiddenProperty ?? (() => {})}
         />

--- a/src/components/skeleton/listingsDetail/ListingDetailLoadingSkeleton.tsx
+++ b/src/components/skeleton/listingsDetail/ListingDetailLoadingSkeleton.tsx
@@ -1,12 +1,44 @@
-import BottomActionBar from "@/components/common/BottomActionBar";
+import { useEffect } from "react";
+
+import { AxiosError } from "axios";
+
+import AlertMessage from "@/components/common/AlertMessage";
 import BackHeader from "@/components/layout/header/BackHeader";
 import DetailTabs from "@/components/listings/DetailTabs";
 
+import { PropertyErrorResponse } from "@/types/property";
+
 import ListingContentSkeleton from "./ListingContentSkeleton";
 
-const ListingDetailLoadingSkeleton = ({ mode }: { mode?: string | null }) => {
+type Props = {
+  mode?: string | null;
+  isError?: boolean;
+  error?: unknown;
+  onHiddenProperty?: () => void;
+};
+
+const ListingDetailLoadingSkeleton = ({
+  mode,
+  isError,
+  error,
+  onHiddenProperty,
+}: Props) => {
   const isConfirmMode = mode === "confirm";
   const isEditMode = mode === "edit";
+
+  const isHidden =
+    isError &&
+    (error as AxiosError<PropertyErrorResponse>)?.response?.data
+      ?.serviceCode === "PROPERTY_IS_HIDDEN";
+
+  useEffect(() => {
+    if (isHidden) {
+      const timeout = setTimeout(() => {
+        onHiddenProperty?.();
+      }, 1500);
+      return () => clearTimeout(timeout);
+    }
+  }, [isHidden, onHiddenProperty]);
 
   return (
     <>
@@ -28,15 +60,14 @@ const ListingDetailLoadingSkeleton = ({ mode }: { mode?: string | null }) => {
           </div>
         </div>
       </div>
-      <BottomActionBar
-        label={
-          isConfirmMode
-            ? "홈으로 이동"
-            : isEditMode
-              ? "거래한 게스트 입력하기"
-              : "뷰잉 예약하기"
-        }
-      />
+
+      {isHidden && (
+        <AlertMessage
+          message="숨김 처리된 매물입니다."
+          className="bottom-3"
+          onDone={onHiddenProperty ?? (() => {})}
+        />
+      )}
     </>
   );
 };

--- a/src/hooks/property/useProperty.ts
+++ b/src/hooks/property/useProperty.ts
@@ -7,6 +7,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 
 import {
   completeTrade,
@@ -22,6 +23,7 @@ import {
 import {
   MyPropertiesParams,
   Property,
+  PropertyErrorResponse,
   PropertyViewType,
   SummaryProperty,
 } from "@/types/property";
@@ -38,11 +40,12 @@ export const usePropertyList = <T extends PropertyViewType>(params: {
 };
 
 export const usePropertyDetailList = (propertyId: string) => {
-  return useQuery({
+  return useQuery<Property, AxiosError<PropertyErrorResponse>>({
     queryKey: ["propertyDetailList", propertyId],
     queryFn: () => fetchPropertyDetailList(propertyId),
     enabled: !!propertyId,
     staleTime: 0,
+    retry: false,
     refetchOnMount: true,
   });
 };

--- a/src/hooks/viewing/useViewing.ts
+++ b/src/hooks/viewing/useViewing.ts
@@ -114,11 +114,12 @@ export const usePutViewingPropertyNotes = () => {
 export const useViewingGuests = (
   propertyId: number,
   status?: ViewingStatus[],
+  enabled = true,
 ) => {
   return useQuery({
     queryKey: ["viewingGuests", propertyId, status],
     queryFn: () => fetchViewingGuests(propertyId, status),
-    enabled: !!propertyId,
+    enabled: enabled && !!propertyId,
     staleTime: 0,
   });
 };

--- a/src/types/property.ts
+++ b/src/types/property.ts
@@ -183,3 +183,15 @@ export interface MyPropertiesParams {
   tradeStatus?: "BEFORE" | "IN_PROGRESS" | "COMPLETED";
   displayStatus?: "ACTIVE" | "INACTIVE";
 }
+
+// 매물 상세 에러 처리
+export interface PropertyErrorResponse {
+  serviceCode: string;
+  message: string;
+  data: {
+    statusCode: number;
+    message: string;
+    codeName: string;
+  };
+  success: boolean;
+}


### PR DESCRIPTION
### 🔥 작업 내용
- 숨김 매물 상세 페이지 접근 시 백에서 404 & PROPERTY_IS_HIDDEN 서비스 코드명을 보내줄 경우 토스트를 띄우도록 구현했습니다.
- 상세 페이지에서 호스트가 아닐 경우 뷰잉 게스트 조회를 하지 않도록 enabled 조건을 추가하였습니다.


### 📸 작업 내역 스크린샷

https://github.com/user-attachments/assets/574a8073-c993-4f6c-b87b-a337438a8f58



### 🔗 이슈
- #93 
