### PR TITLE
✨ Feat: 내놓은 매물 수정 페이지

### DIFF
--- a/src/app/listings/[id]/edit/description/page.tsx
+++ b/src/app/listings/[id]/edit/description/page.tsx
@@ -1,0 +1,2 @@
+const DescriptionEdit = () => {};
+export default DescriptionEdit;

--- a/src/app/listings/[id]/edit/description/page.tsx
+++ b/src/app/listings/[id]/edit/description/page.tsx
@@ -1,2 +1,6 @@
-const DescriptionEdit = () => {};
+import ListingDescription from "@/components/listings/create/listingDescription/ListingDescription";
+
+const DescriptionEdit = () => {
+  return <ListingDescription edit/>;
+};
 export default DescriptionEdit;

--- a/src/app/listings/[id]/edit/kind/page.tsx
+++ b/src/app/listings/[id]/edit/kind/page.tsx
@@ -2,19 +2,36 @@
 
 import { useParams, useRouter } from "next/navigation";
 
+import { useEffect } from "react";
+
 import { useListingStore } from "@/stores/useListingStore";
+
+import { usePropertyDetailEditList } from "@/hooks/property/useProperty";
+
+import toPostPropertyDetail from "@/utils/toPostPropertyDetail";
 
 import BottomActionBar from "@/components/common/BottomActionBar";
 import ListingType from "@/components/listings/create/listingType/ListingType";
 
 const EditKind = () => {
   const router = useRouter();
-  const { id } = useParams();
+  const params = useParams();
+  const id = params.id as string;
+  const { data } = usePropertyDetailEditList(id ?? "");
+
   const { setListingType } = useListingStore();
+
+  useEffect(() => {
+    if (data) {
+      const parsed = toPostPropertyDetail(data);
+      setListingType(parsed.kind);
+    }
+  }, [data, setListingType]);
+
   const handleSave = () => {
-    console.log("저장");
     router.push(`/listings/${id}/edit`);
   };
+
   return (
     <>
       <ListingType

--- a/src/app/listings/[id]/edit/listingDetails/page.tsx
+++ b/src/app/listings/[id]/edit/listingDetails/page.tsx
@@ -23,14 +23,14 @@ import BottomActionBar from "@/components/common/BottomActionBar";
 import Divider from "@/components/common/Divider";
 import BackHeader from "@/components/layout/header/BackHeader";
 import FunnelStepMenu from "@/components/listings/create/common/FunnelStepMenu";
+import ListingDetailsDropdownContent from "@/components/listings/create/listingDetails/ListingDetailsDropdownContent";
 
 import { QUESTION_MAP } from "@/constants/question-map";
 
+import { ListingDetailsOption } from "@/types/createPropertyAnswer";
 import {
   RentInternalDetails,
-  RentPropertyDetail,
   ShareInternalDetails,
-  SharePropertyDetail,
 } from "@/types/listingDetailPost";
 
 import DownArrow from "@/public/svgs/common/down-arrow.svg";
@@ -38,6 +38,12 @@ import DownArrow from "@/public/svgs/common/down-arrow.svg";
 const ListingDetailsEdit = () => {
   const {
     listingType,
+    rentPropertyType,
+    sharePropertyType,
+    rentCapacityPeople,
+    shareCapacityPeople,
+    rentInternalDetails,
+    shareInternalDetails,
     optionItemIds,
     setListingType,
     setRentPropertyType,
@@ -48,6 +54,7 @@ const ListingDetailsEdit = () => {
     setShareInternalDetails,
     setOptionItemIds,
   } = useListingStore();
+
   const router = useRouter();
   const params = useParams();
   const id = params.id as string;
@@ -92,8 +99,6 @@ const ListingDetailsEdit = () => {
   if (!listingType) return null;
   if (!listing) return null;
 
-  console.log("listing 전체:", listing);
-
   const handleItemClick = () => {
     setShowAlert(true);
   };
@@ -107,31 +112,23 @@ const ListingDetailsEdit = () => {
 
         switch (item.id) {
           case "propertyType": {
-            if (listing.jsonDiscriminator === "SHARE") {
-              value = formatPropertySubType(
-                (listing as SharePropertyDetail).sharePropertySubType,
-                "SHARE",
-              );
-            } else if (listing.jsonDiscriminator === "RENT") {
-              value = formatPropertySubType(
-                (listing as RentPropertyDetail).rentPropertySubType,
-                "RENT",
-              );
+            if (listingType === "SHARE" && sharePropertyType) {
+              value = formatPropertySubType(sharePropertyType, listingType);
+            } else if (listingType === "RENT" && rentPropertyType) {
+              value = formatPropertySubType(rentPropertyType, listingType);
+            } else {
+              value = "N/A";
             }
             break;
           }
 
           case "capacityPeople": {
-            if (listing.jsonDiscriminator === "SHARE") {
-              value = formatCapcityPeople(
-                (listing as SharePropertyDetail).capacityShare,
-                "SHARE",
-              );
-            } else if (listing.jsonDiscriminator === "RENT") {
-              value = formatCapcityPeople(
-                (listing as RentPropertyDetail).capacityRent,
-                "RENT",
-              );
+            if (listingType === "SHARE" && shareCapacityPeople !== null) {
+              value = formatCapcityPeople(shareCapacityPeople, "SHARE");
+            } else if (listingType === "RENT" && rentCapacityPeople !== null) {
+              value = formatCapcityPeople(rentCapacityPeople, "RENT");
+            } else {
+              value = "N/A";
             }
             break;
           }
@@ -152,30 +149,35 @@ const ListingDetailsEdit = () => {
           }
 
           case "internalDetails": {
-            const val = listing.internalDetails;
+            const val =
+              listingType === "SHARE"
+                ? shareInternalDetails
+                : rentInternalDetails;
+
+            if (!val) {
+              value = "답변내용";
+              break;
+            }
 
             const areaLabels = ["internalArea", "totalArea"];
             const areaTexts = areaLabels
               .filter(key => val[key as keyof typeof val])
               .map(() => "면적");
 
-            const resident =
-              "totalResidents" in val && val.totalResidents ? "거주인" : "";
-            const shareBathroom =
-              "totalBathUser" in val && val.totalBathUser ? "욕실 쉐어" : "";
-
+            const resident = "";
+            const shareBathroom = "";
             let rooms = "";
             let bathrooms = "";
             let veranda = "";
             let yard = "";
             let withOwner = "";
 
-            if (listing.jsonDiscriminator === "SHARE") {
+            if (listingType === "SHARE") {
               const shareVal = val as ShareInternalDetails;
               bathrooms = shareVal.totalBathUser ? "욕실 쉐어" : "";
               rooms = shareVal.totalResidents ? "거주인" : "";
               withOwner = shareVal.withPropertyOwner ? "집주인 거주" : "";
-            } else if (listing.jsonDiscriminator === "RENT") {
+            } else if (listingType === "RENT") {
               const rentVal = val as RentInternalDetails;
               rooms = rentVal.numberOfRoom ? "방 개수" : "";
               bathrooms = rentVal.numberOfBath ? "욕실 개수" : "";
@@ -238,7 +240,12 @@ const ListingDetailsEdit = () => {
                 />
               </div>
             </div>
-
+            {open === item.id && (
+              <ListingDetailsDropdownContent
+                id={item.id as ListingDetailsOption["type"]}
+                onSelect={() => {}}
+              />
+            )}
             {index < array.length - 1 && <Divider className="my-1" />}
           </div>
         );

--- a/src/app/listings/[id]/edit/listingDetails/page.tsx
+++ b/src/app/listings/[id]/edit/listingDetails/page.tsx
@@ -207,7 +207,7 @@ const ListingDetailsEdit = () => {
           }
 
           default: {
-            value = "답변내용1";
+            value = "답변내용";
             break;
           }
         }

--- a/src/app/listings/[id]/edit/listingDetails/page.tsx
+++ b/src/app/listings/[id]/edit/listingDetails/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useParams, useSearchParams } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 
 import { useEffect, useMemo, useState } from "react";
 
@@ -16,7 +16,6 @@ import {
   formatIsBrokered,
   formatPropertySubType,
 } from "@/utils/formatter/detailFormatter";
-
 import toPostPropertyDetail from "@/utils/toPostPropertyDetail";
 
 import AlertMessage from "@/components/common/AlertMessage";
@@ -49,7 +48,7 @@ const ListingDetailsEdit = () => {
     setShareInternalDetails,
     setOptionItemIds,
   } = useListingStore();
-
+  const router = useRouter();
   const params = useParams();
   const id = params.id as string;
   const { data, isLoading, error } = usePropertyDetailEditList(id ?? "");
@@ -147,7 +146,7 @@ const ListingDetailsEdit = () => {
             break;
           }
 
-          case "isbrokered": {
+          case "isBrokered": {
             value = formatIsBrokered(optionItemIds);
             break;
           }
@@ -208,7 +207,7 @@ const ListingDetailsEdit = () => {
           }
 
           default: {
-            value = "답변내용";
+            value = "답변내용1";
             break;
           }
         }
@@ -251,7 +250,12 @@ const ListingDetailsEdit = () => {
           className="bottom-[70px]"
         />
       )}
-      <BottomActionBar label="저장" />
+      <BottomActionBar
+        label="저장"
+        onClick={() => {
+          router.push(`/listings/${id}/edit`);
+        }}
+      />
     </>
   );
 };

--- a/src/app/listings/[id]/edit/movingConditions/page.tsx
+++ b/src/app/listings/[id]/edit/movingConditions/page.tsx
@@ -1,42 +1,82 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useListingStore } from "@/stores/useListingStore";
 import clsx from "clsx";
 
-// import { usePropertyDetailEditList } from "@/hooks/property/useProperty";
+import { usePropertyDetailEditList } from "@/hooks/property/useProperty";
+
+import { formatMeetingDay } from "@/utils/formatter/dateFormatter";
+import toPostPropertyDetail from "@/utils/toPostPropertyDetail";
 
 import AlertMessage from "@/components/common/AlertMessage";
 import BottomActionBar from "@/components/common/BottomActionBar";
 import Divider from "@/components/common/Divider";
 import BackHeader from "@/components/layout/header/BackHeader";
 import FunnelStepMenu from "@/components/listings/create/common/FunnelStepMenu";
+import MovingConditionDropdownContent from "@/components/listings/create/movingConditions/MovingConditionDropdownContent";
 
+import { CATEGORY_OPTIONS } from "@/constants/property-category";
 import { COMMON_MOVING_CONDITIONS } from "@/constants/question-map";
+
+import { MovingConditionsOption } from "@/types/createPropertyAnswer";
 
 import DownArrow from "@/public/svgs/common/down-arrow.svg";
 
 const MovingConditionsEdit = () => {
   const fixedKey = "movingConditions";
   const [showAlert, setShowAlert] = useState(false);
-  // const params = useParams();
-  // // const id = params.id as string;
+  const params = useParams();
+  const id = params.id as string;
+  const router = useRouter();
 
-  // const { data, isLoading, error } = usePropertyDetailEditList(id ?? "");
+  const { data } = usePropertyDetailEditList(id ?? "");
 
   const searchParams = useSearchParams();
   const open = searchParams.get("open");
 
-  const { genderPreference, livingConditions, moveInInfo } = useListingStore();
+  const {
+    genderPreference,
+    livingConditions,
+    moveInInfo,
+    optionItemIds,
+    setGenderPreference,
+    setLivingConditions,
+    setMoveInInfo,
+    setOptionItemIds,
+  } = useListingStore();
+
+  const listing = useMemo(() => {
+    if (!data) return null;
+    return toPostPropertyDetail(data);
+  }, [data]);
+
+  useEffect(() => {
+    if (!listing) return;
+    setOptionItemIds(listing.optionItemIds);
+    setMoveInInfo(listing.moveInInfo);
+    setLivingConditions(listing.livingConditions);
+    setGenderPreference(listing.genderPreference);
+  }, [listing]);
+
+  console.log(listing);
 
   const handleItemClick = () => {
     setShowAlert(true);
   };
 
   const getConditionValue = (id: string) => {
+    const AVAILABLE_KEY_LABEL_MAP: Record<string, string> = {
+      흡연자: "흡연자",
+      반려동물: "반려동물",
+      "외부인 방문": "외부인",
+      주차: "주차",
+      "주방 사용": "주방",
+    };
+
     switch (id) {
       case "genderPreference":
         return genderPreference === "ANY"
@@ -46,19 +86,95 @@ const MovingConditionsEdit = () => {
             : genderPreference === "FEMALE_ONLY"
               ? "여자만"
               : "커플 가능";
-      case "livingConditions":
-        return `${livingConditions?.minimumStayWeeks || ""} / ${livingConditions?.noticePeriodWeeks || ""}`;
-      case "moveInInfo":
-        return moveInInfo?.immediate
-          ? "즉시 입주 가능"
-          : `${moveInInfo?.availableFrom} ~ ${moveInInfo?.availableTo}`;
+      case "livingConditions": {
+        const parts = [];
+        if (livingConditions?.noticePeriodWeeks)
+          parts.push(`노티스 ${livingConditions?.noticePeriodWeeks}주`);
+        if (livingConditions?.minimumStayWeeks)
+          parts.push(`최소 ${livingConditions?.minimumStayWeeks}주`);
+        if (livingConditions?.contractTerms) parts.push("계약 형태");
+        return parts.join(", ");
+      }
+      case "moveInInfo":{
+        const { availableFrom, availableTo, immediate, negotiable } =
+          moveInInfo;
+
+        const moveInParts = [];
+
+        const from = availableFrom
+          ? formatMeetingDay(availableFrom).date
+          : null;
+        const to = availableTo ? formatMeetingDay(availableTo).date : null;
+
+        if (from && to) moveInParts.push(`${from} ~ ${to}`);
+        else moveInParts.push("날짜 미정");
+
+        if (immediate) moveInParts.push("즉시 입주");
+        if (negotiable) moveInParts.push("협의 가능");
+
+        return moveInParts.join(", ");
+      }
+      case "additionalInfo": {
+        const selectedIds = optionItemIds;
+        const additionalInfoItems = CATEGORY_OPTIONS[3].items;
+
+        const selectedCategories = Object.entries(additionalInfoItems)
+          .filter(([, options]) =>
+            options.some(option => selectedIds.includes(option.optionId)),
+          )
+          .map(([category]) => AVAILABLE_KEY_LABEL_MAP[category] ?? category);
+
+        return selectedCategories.join(", ");
+      }
       default:
         return "-";
     }
   };
 
+  const getConditionValueForDropdown = (
+    id: string,
+  ): MovingConditionsOption | undefined => {
+    switch (id) {
+      case "genderPreference":
+        return { type: "genderPreference", value: genderPreference };
+      case "livingConditions":
+        return { type: "livingConditions", value: livingConditions };
+      case "moveInInfo":
+        return { type: "moveInInfo", value: moveInInfo };
+      case "additionalInfo":
+        return { type: "optionItemIds", value: optionItemIds };
+      default:
+        return undefined;
+    }
+  };
+
+  const handleSelect = (id: string, selected: MovingConditionsOption) => {
+    switch (id) {
+      case "genderPreference":
+        if (selected.type === "genderPreference") {
+          setGenderPreference(selected.value);
+        }
+        break;
+      case "livingConditions":
+        if (selected.type === "livingConditions") {
+          setLivingConditions(selected.value);
+        }
+        break;
+      case "moveInInfo":
+        if (selected.type === "moveInInfo" && selected.value != null) {
+          setMoveInInfo(selected.value);
+        }
+        break;
+      case "additionalInfo":
+        if (selected.type === "optionItemIds") {
+          setOptionItemIds(selected.value);
+        }
+        break;
+    }
+  };
+
   return (
-    <div>
+    <div className="pb-[70px]">
       <BackHeader />
       <FunnelStepMenu fixedKey={fixedKey} />
       {COMMON_MOVING_CONDITIONS.map((item, index, array) => {
@@ -91,6 +207,16 @@ const MovingConditionsEdit = () => {
               </div>
             </div>
 
+            {open === item.id && (
+              <div>
+                <MovingConditionDropdownContent
+                  id={item.id}
+                  value={getConditionValueForDropdown(item.id)}
+                  onSelect={value => handleSelect(item.id, value)}
+                />
+              </div>
+            )}
+
             {index < array.length - 1 && <Divider className="my-1" />}
           </div>
         );
@@ -102,7 +228,12 @@ const MovingConditionsEdit = () => {
           className="bottom-[70px]"
         />
       )}
-      <BottomActionBar label="저장" />
+      <BottomActionBar
+        label="저장"
+        onClick={() => {
+          router.push(`/listings/${id}/edit`);
+        }}
+      />
     </div>
   );
 };

--- a/src/app/listings/[id]/edit/page.tsx
+++ b/src/app/listings/[id]/edit/page.tsx
@@ -2,7 +2,7 @@
 
 import { useParams, useRouter } from "next/navigation";
 
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { usePropertyDetailEditList } from "@/hooks/property/useProperty";
 
@@ -43,9 +43,6 @@ const ListingsEdit = () => {
     }
   }, [data]);
 
-  const handleRemoveImage = useCallback((index: number) => {
-    setPreviewUrls(prev => prev.filter((_, i) => i !== index));
-  }, []);
 
   if (isLoading) return <div>로딩 중...</div>;
   if (error || !originalDetail || !currentDetail)
@@ -66,7 +63,7 @@ const ListingsEdit = () => {
             router.push(`/listings/${id}/edit/addressPhoto?subStep=photo`)
           }
         >
-          <ImageSlider images={previewUrls} onRemove={handleRemoveImage} />
+          <ImageSlider images={previewUrls} onRemove={()=>{}} />
         </div>
         {currentDetail && originalDetail && (
           <DropDownSection

--- a/src/components/common/GoogleMap.tsx
+++ b/src/components/common/GoogleMap.tsx
@@ -12,8 +12,9 @@ const GoogleMap = ({ lat, lng }: { lat: number; lng: number }) => {
   return (
     <APIProvider apiKey={API_KEY}>
       <Map
+        key={`${lat}-${lng}`}
         mapId="caf14668283853a63656a7d1"
-        defaultCenter={{ lat, lng }}
+        center={{ lat, lng }}
         defaultZoom={16}
         gestureHandling="greedy"
         disableDefaultUI={true}

--- a/src/components/listings/create/addressPhoto/AddressField.tsx
+++ b/src/components/listings/create/addressPhoto/AddressField.tsx
@@ -9,6 +9,10 @@ import clsx from "clsx";
 
 import { fetchPlaceDetails, fetchPlaceSuggestions } from "@/apis/googlePlaces";
 
+import { usePropertyDetailEditList } from "@/hooks/property/useProperty";
+
+import toPostPropertyDetail from "@/utils/toPostPropertyDetail";
+
 import BottomActionBar from "@/components/common/BottomActionBar";
 import GoogleMap from "@/components/common/GoogleMap";
 
@@ -46,10 +50,34 @@ const AddressField = ({ onNext, edit }: AddressFieldProps) => {
   const [suggestions, setSuggestions] = useState<
     { placeId: string; text: string }[]
   >([]);
+
   const router = useRouter();
   const { id } = useParams();
+  const { data } = usePropertyDetailEditList(id as string);
 
   const abortControllerRef = useRef<AbortController | null>(null);
+
+
+  useEffect(() => {
+    if (edit && data) {
+      const parsed = toPostPropertyDetail(data);
+      if (parsed.region) {
+        setAddressData(parsed.region);
+        setSearchKeyword(
+          [
+            parsed.region.streetNumber,
+            parsed.region.streetName,
+            parsed.region.suburb,
+            parsed.region.state,
+          ]
+            .filter(Boolean)
+            .join(" "),
+        );
+        setIsSearchClicked(true);
+        setSelectedAddress(parsed.region);
+      }
+    }
+  }, [edit, data, setAddressData, setSearchKeyword]);
 
   useEffect(() => {
     if (!searchKeyword.trim()) {
@@ -120,6 +148,7 @@ const AddressField = ({ onNext, edit }: AddressFieldProps) => {
   };
 
   console.log(addressData);
+
   return (
     <div className="flex flex-col gap-2">
       <div className="text-heading3 px-4 py-4 text-gray-900">
@@ -178,6 +207,7 @@ const AddressField = ({ onNext, edit }: AddressFieldProps) => {
             </div>
           )}
         </div>
+        
         {isSearchClicked && selectedAddress && (
           <div className="h-[343px] w-[343px] py-3">
             <GoogleMap

--- a/src/components/listings/create/addressPhoto/AddressField.tsx
+++ b/src/components/listings/create/addressPhoto/AddressField.tsx
@@ -57,7 +57,6 @@ const AddressField = ({ onNext, edit }: AddressFieldProps) => {
 
   const abortControllerRef = useRef<AbortController | null>(null);
 
-
   useEffect(() => {
     if (edit && data) {
       const parsed = toPostPropertyDetail(data);
@@ -101,6 +100,7 @@ const AddressField = ({ onNext, edit }: AddressFieldProps) => {
   const handleSelectSuggestion = async (placeId: string, text: string) => {
     setSearchKeyword(text);
     setSuggestions([]);
+    setIsFocused(false);
 
     const details = await fetchPlaceDetails(placeId);
     if (!details) return;
@@ -207,7 +207,7 @@ const AddressField = ({ onNext, edit }: AddressFieldProps) => {
             </div>
           )}
         </div>
-        
+
         {isSearchClicked && selectedAddress && (
           <div className="h-[343px] w-[343px] py-3">
             <GoogleMap

--- a/src/components/listings/create/addressPhoto/PhotoField.tsx
+++ b/src/components/listings/create/addressPhoto/PhotoField.tsx
@@ -7,6 +7,9 @@ import { useListingStore } from "@/stores/useListingStore";
 import { getPropertyPresignedUrl } from "@/apis/s3Upload";
 
 import useMultipleImageUpload from "@/hooks/common/useMultipleImageUpload";
+import { usePropertyDetailEditList } from "@/hooks/property/useProperty";
+
+import toPostPropertyDetail from "@/utils/toPostPropertyDetail";
 
 import AlertMessage from "@/components/common/AlertMessage";
 import BottomActionBar from "@/components/common/BottomActionBar";
@@ -29,6 +32,7 @@ interface PhotoFieldProps {
 const PhotoField = ({ onNext, edit = false }: PhotoFieldProps) => {
   const router = useRouter();
   const { id } = useParams();
+  const { data } = usePropertyDetailEditList(id as string);
 
   const { photoUrls, setPhotoUrls } = useListingStore();
   const [previewUrls, setPreviewUrls] = useState<string[]>(photoUrls); // 이미지 URL 미리보기
@@ -59,19 +63,22 @@ const PhotoField = ({ onNext, edit = false }: PhotoFieldProps) => {
   }, []);
 
   useEffect(() => {
+    if (edit && data) {
+      const parsed = toPostPropertyDetail(data);
+      if (Array.isArray(parsed.photoUrls)) {
+        setPhotoUrls(parsed.photoUrls);
+      }
+    }
+  }, [edit, data, setPhotoUrls]);
+
+  useEffect(() => {
     if (photoUrls.length > 0) {
       setPreviewUrls(photoUrls);
     }
   }, [photoUrls]);
 
-  useEffect(() => {
-    if (previewUrls.length > 0) {
-      setPhotoUrls(previewUrls); // 이미지 URL을 업데이트
-    }
-  }, [previewUrls]);
-
   return (
-    <div className="max-w-[375px]">
+    <div className="max-w-[375px] pb-[70px]">
       <div className="flex flex-col gap-2">
         <div className="text-heading3 p-4 text-gray-900">
           직접 촬영한 매물 사진을 올려주세요
@@ -135,7 +142,6 @@ const PhotoField = ({ onNext, edit = false }: PhotoFieldProps) => {
                 console.log("저장");
               },
               variant: "outline",
-
             },
             {
               label: "다음",

--- a/src/components/listings/create/listingDescription/ListingDescription.tsx
+++ b/src/components/listings/create/listingDescription/ListingDescription.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+
 import { useRef, useState } from "react";
 
 import { useListingStore } from "@/stores/useListingStore";
@@ -7,10 +11,17 @@ import TextareaField from "@/components/common/TextareaField";
 import BackHeader from "@/components/layout/header/BackHeader";
 
 interface ListingDescriptionProps {
-  onNext: () => void;
-  onPrev: () => void;
+  onNext?: () => void;
+  onPrev?: () => void;
+  edit?: boolean;
 }
-const ListingDescription = ({ onNext }: ListingDescriptionProps) => {
+const ListingDescription = ({
+  onNext,
+  edit = false,
+}: ListingDescriptionProps) => {
+  const router = useRouter();
+  const { id } = useParams();
+
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { description, setDescription } = useListingStore();
   const [text, setText] = useState(description || "");
@@ -50,27 +61,36 @@ const ListingDescription = ({ onNext }: ListingDescriptionProps) => {
         placeholder="주변 인프라, 편리한 교통, 깔끔한 집 등 다양하게 매물을 홍보해요"
         gap="gap-2"
       />
-      <BottomActionBar
-        buttons={[
-          {
-            label: "저장",
-            onClick: () => {
-              setDescription(text);
-              console.log("저장");
+      {!edit ? (
+        <BottomActionBar
+          buttons={[
+            {
+              label: "저장",
+              onClick: () => {
+                setDescription(text);
+                console.log("저장");
+              },
+              variant: "outline",
             },
-            variant: "outline",
-          },
-          {
-            label: "다음",
-            onClick: () => {
-              setDescription(text);
-              onNext();
+            {
+              label: "다음",
+              onClick: () => {
+                setDescription(text);
+                if (onNext) onNext();
+              },
+              variant: "filled",
+              disabled: !text,
             },
-            variant: "filled",
-            disabled: !text,
-          },
-        ]}
-      />
+          ]}
+        />
+      ) : (
+        <BottomActionBar
+          label="저장"
+          onClick={() => {
+            router.push(`/listings/${id}/edit`);
+          }}
+        />
+      )}
     </>
   );
 };

--- a/src/components/listings/create/listingDescription/ListingDescription.tsx
+++ b/src/components/listings/create/listingDescription/ListingDescription.tsx
@@ -2,9 +2,13 @@
 
 import { useParams, useRouter } from "next/navigation";
 
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 
 import { useListingStore } from "@/stores/useListingStore";
+
+import { usePropertyDetailEditList } from "@/hooks/property/useProperty";
+
+import toPostPropertyDetail from "@/utils/toPostPropertyDetail";
 
 import BottomActionBar from "@/components/common/BottomActionBar";
 import TextareaField from "@/components/common/TextareaField";
@@ -20,11 +24,24 @@ const ListingDescription = ({
   edit = false,
 }: ListingDescriptionProps) => {
   const router = useRouter();
-  const { id } = useParams();
+  const params = useParams();
+  const id = params.id as string;
+  const { data } = usePropertyDetailEditList(id ?? "");
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { description, setDescription } = useListingStore();
   const [text, setText] = useState(description || "");
+
+  useEffect(() => {
+    if (edit && data) {
+      const parsed = toPostPropertyDetail(data);
+      const fetchedDescription = parsed.description || "";
+      setText(fetchedDescription);
+      setDescription(fetchedDescription);
+    } else if (!edit) {
+      setText(description || "");
+    }
+  }, [edit, data]);
 
   const handleResize = () => {
     const textarea = textareaRef.current;

--- a/src/components/listings/create/listingDetails/ListingDetailsDropdownContent.tsx
+++ b/src/components/listings/create/listingDetails/ListingDetailsDropdownContent.tsx
@@ -32,7 +32,7 @@ type ValueOf<T extends ListingDetailsOption["type"]> = Extract<
 
 interface Props<T extends ListingDetailsOption["type"]> {
   id: T;
-  value: ValueOf<T> | null;
+  value?: ValueOf<T> | null;
   onSelect: (value: ValueOf<T> | null) => void;
 }
 

--- a/src/components/listings/create/movingConditions/MovingConditionDropdownContent.tsx
+++ b/src/components/listings/create/movingConditions/MovingConditionDropdownContent.tsx
@@ -12,7 +12,7 @@ import MoveInfoContent from "./MoveInfoContent";
 
 interface MovingConditionDropdownContentProps {
   id: string;
-  value: MovingConditionsOption;
+  value: MovingConditionsOption | undefined;
   onSelect: (value: MovingConditionsOption) => void;
 }
 

--- a/src/components/listings/detailShow/DropDownSection.tsx
+++ b/src/components/listings/detailShow/DropDownSection.tsx
@@ -57,6 +57,7 @@ const DropDownSection = ({
         return router.push(`/listings/${id}/edit/listingDetails?open=${key}`);
       case "genderPreference":
       case "livingConditions":
+      case "moveInInfo":
       case "additionalInfo":
         return router.push(`/listings/${id}/edit/movingConditions?open=${key}`);
       case "costDetails":

--- a/src/utils/formatter/detailFormatter.tsx
+++ b/src/utils/formatter/detailFormatter.tsx
@@ -100,8 +100,17 @@ export const formatInternalDetails = (
 ) => {
   if (!details) return <div>N/A</div>;
 
-  const displayValue = (value: number | undefined | null) =>
-    value === null || value === undefined ? "(-)" : value;
+  const displayValue = (value: number | undefined | null) => {
+    if (value === null || value === undefined) return "(-)";
+
+    const formatted = value.toFixed(1);
+
+    // 최대 길이 5자리로 자르기 (예: "123.4", "12.34" 등)
+    if (formatted.length > 5) {
+      return formatted.slice(0, 5);
+    }
+    return formatted;
+  };
 
   return (
     <div className="flex flex-col divide-y divide-gray-100">

--- a/src/utils/formatter/detailFormatter.tsx
+++ b/src/utils/formatter/detailFormatter.tsx
@@ -105,7 +105,6 @@ export const formatInternalDetails = (
 
     const formatted = value.toFixed(1);
 
-    // 최대 길이 5자리로 자르기 (예: "123.4", "12.34" 등)
     if (formatted.length > 5) {
       return formatted.slice(0, 5);
     }


### PR DESCRIPTION
### 🔥 작업 내용

- 내놓은 매물 수정 시, 해당하는 드롭다운을 열어 수정 페이지로 들어가지도록함
- 매물 등록 당시의 하나의 funnel-step을 기준으로 수정페이지 분리 (다음과 같은 형식으로 페이지 분리)
 `/listings/41/edit/addressPhoto?subStep=address` `substep=photo`
` listings/41/edit/listingDetails?open=propertyType`

- 수정 첫 화면에서  이미지 슬라이더에서 사진 삭제 되지 않도록 반영
- get해온 property data 먼저 띄워줌
- 드롭다운이 있는 응답 페이지의 경우 다른 영역의 드롭다운을 클릭한 경우 토스트 경고 메세지 추가
- 주소 변경 시에, 고정되었던 핀 자동으로 lat, lng값으로 이동 시키게 설정
- 계약사항의 경우 뷰잉관련 정보는 수정하는 칸이 없으므로 costDetail만 추가

### 🤔 추후 작업 사항

- 내놓은 매물 patch하는 api 추가할 것

### 📸 작업 내역 스크린샷

- <img width="532" height="855" alt="image" src="https://github.com/user-attachments/assets/86687a3d-b65f-4394-9d7e-23ba66429906" />
`/listings/41/edit/addressPhoto?subStep=photo`

- <img width="496" height="860" alt="image" src="https://github.com/user-attachments/assets/60287fdd-ffe5-4b74-ae71-82df1cc01a15" />
`listings/41/edit/kind`

-  <img width="484" height="861" alt="image" src="https://github.com/user-attachments/assets/dbd95c82-bf06-470c-95fa-6eab8bd007a4" />
`listings/41/edit/addressPhoto?subStep=address`

- <img width="502" height="858" alt="image" src="https://github.com/user-attachments/assets/2aecfa38-7cfc-4320-a518-0955a36f9502" />
- <img width="500" height="859" alt="image" src="https://github.com/user-attachments/assets/77681189-6059-4f56-bb32-52adbd370dd9" />
`listings/41/edit/listingDetails?open=propertyType`

<img width="501" height="865" alt="image" src="https://github.com/user-attachments/assets/c96f6365-b0d9-4af1-a04a-0eee2daa5fdf" />
`http://localhost:3000/listings/41/edit/description`
### 🔗 이슈

- #95 
