### PR TITLE
🎨 Design: max-width 기준으로 전체 레이아웃 재정렬

### DIFF
--- a/src/apis/googlePlacesApi.ts
+++ b/src/apis/googlePlacesApi.ts
@@ -51,7 +51,6 @@ export const fetchPlaceSuggestions = async (
     return [];
   }
 };
-
 export const fetchPlaceDetailSuggestions = async (
   input: string,
   signal?: AbortSignal,
@@ -69,15 +68,32 @@ export const fetchPlaceDetailSuggestions = async (
     if (!res.ok) throw new Error("Failed to fetch predictions");
 
     const data = (await res.json()) as GooglePlacesAPIResponse;
-    
+
     return (
       data?.suggestions?.map(s => ({
         placeId: s.placePrediction.placeId,
         text: s.placePrediction.text.text,
       })) ?? []
     );
-  } catch (error) {
-    console.error("fetchPlaceDetailSuggestions error", error);
+  } catch (err: unknown) {
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      "code" in err &&
+      (err as { code?: string }).code === "ERR_CANCELED"
+    ) {
+      return [];
+    }
+
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      "name" in err &&
+      (err as { name?: string }).name === "AbortError"
+    ) {
+      return [];
+    }
+
     return [];
   }
 };

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -40,7 +40,7 @@ const LoginPage = () => {
           <GoogleLoginButton />
           <button
             onClick={handleGuestClick}
-            className="flex h-6 w-[343px] cursor-pointer items-center justify-center gap-2 bg-white py-[10px]"
+            className="flex h-6 w-full max-w-[398px] cursor-pointer items-center justify-center gap-2 bg-white py-[10px]"
           >
             <GuestIcon />
             <span className="text-lab1-b text-mint underline">

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -55,7 +55,9 @@ const Home = () => {
         <FilterBar />
         <ListingList fallbackSuburb={selectedSuburb} />
       </div>
-      {isLoggedIn && <AddListingFab />}
+      <div className="relative mx-auto max-w-[430px]">
+        {isLoggedIn && <AddListingFab />}
+      </div>
     </ContentWrapper>
   );
 };

--- a/src/app/listings/[id]/edit/contractTerms/page.tsx
+++ b/src/app/listings/[id]/edit/contractTerms/page.tsx
@@ -106,7 +106,7 @@ const ContractTermsEdit = () => {
     <div className="pb-[70px]">
       <BackHeader />
       <FunnelStepMenu fixedKey={fixedKey} />
-      <div className="flex h-19 w-[375px] cursor-pointer items-start justify-between p-4">
+      <div className="flex h-19 w-full max-w-[430px] cursor-pointer items-start justify-between p-4">
         <div className="flex flex-col">
           <div className="text-heading3 text-gray-900">
             {COMMON_CONTRACT_TERMS[0].label}

--- a/src/app/listings/[id]/edit/listingDetails/page.tsx
+++ b/src/app/listings/[id]/edit/listingDetails/page.tsx
@@ -348,7 +348,7 @@ const ListingDetailsEdit = () => {
           <div key={item.id}>
             <div
               className={clsx(
-                "flex h-19 w-[375px] cursor-pointer items-start justify-between p-4",
+                "flex h-19 w-full max-w-[430px] cursor-pointer items-start justify-between p-4",
               )}
               onClick={() => {
                 if (open != item.id) handleItemClick();

--- a/src/app/listings/[id]/edit/movingConditions/page.tsx
+++ b/src/app/listings/[id]/edit/movingConditions/page.tsx
@@ -238,7 +238,7 @@ const MovingConditionsEdit = () => {
           <div key={item.id}>
             <div
               className={clsx(
-                "flex h-19 w-[375px] cursor-pointer items-start justify-between p-4",
+                "flex h-19 w-full max-w-[430px] cursor-pointer items-start justify-between p-4",
               )}
               onClick={() => {
                 if (open != item.id) handleItemClick();

--- a/src/app/listings/[id]/edit/page.tsx
+++ b/src/app/listings/[id]/edit/page.tsx
@@ -43,7 +43,6 @@ const ListingsEdit = () => {
     }
   }, [data]);
 
-
   if (isLoading) return <div>로딩 중...</div>;
   if (error || !originalDetail || !currentDetail)
     return <div>데이터를 불러올 수 없습니다.</div>;
@@ -51,7 +50,7 @@ const ListingsEdit = () => {
   // console.log("바뀐값: ", currentDetail);
   return (
     <>
-      <div className="w-[375px] pb-[130px]">
+      <div className="w-full max-w-[430px] pb-[130px]">
         <BackHeader />
         <TitleSection
           title="수정할 정보 섹션을 클릭해주세요"
@@ -63,7 +62,7 @@ const ListingsEdit = () => {
             router.push(`/listings/${id}/edit/addressPhoto?subStep=photo`)
           }
         >
-          <ImageSlider images={previewUrls} onRemove={()=>{}} />
+          <ImageSlider images={previewUrls} onRemove={() => {}} />
         </div>
         {currentDetail && originalDetail && (
           <DropDownSection
@@ -74,7 +73,12 @@ const ListingsEdit = () => {
           />
         )}
       </div>
-      <BottomActionBar label="저장" onClick={()=>{router.push(`/listings/${id}?mode=edit`)}}/>
+      <BottomActionBar
+        label="저장"
+        onClick={() => {
+          router.push(`/listings/${id}?mode=edit`);
+        }}
+      />
     </>
   );
 };

--- a/src/app/listings/[id]/report/page.tsx
+++ b/src/app/listings/[id]/report/page.tsx
@@ -121,7 +121,7 @@ const ListingReportPage = () => {
 
       <div className="flex w-full flex-col gap-2 p-4">
         <span className="text-heading3 text-gray-800">증명자료 (필수)</span>
-        <p className="text-cap1-med max-w-[343px] break-words text-gray-600">
+        <p className="text-cap1-med w-full max-w-[398px] break-words text-gray-600">
           문제가 실제로 발생했음을 보여주는 스크린샷이나 허위 정보와 관련된 증빙
           자료를 첨부해주세요. 첨부된 자료는 운영팀 검토용으로만 사용되며 외부에
           공개되지 않습니다.

--- a/src/app/mypage/profile/edit/page.tsx
+++ b/src/app/mypage/profile/edit/page.tsx
@@ -107,7 +107,7 @@ const ProfileEditPage = () => {
             }}
           />
           {!isLoading && (
-            <div className="w-[343px] pb-[66px]">
+            <div className="w-[calc(100%-32px)] max-w-[398px] pb-[66px]">
               <InputField
                 label="닉네임"
                 placeholder="한영문, 숫자로 5 - 12글자"

--- a/src/app/mypage/profile/verifications/page.tsx
+++ b/src/app/mypage/profile/verifications/page.tsx
@@ -91,7 +91,7 @@ const VerificationPage = () => {
   }, [modals.showAssignModal]);
 
   return (
-    <div className="flex h-screen max-w-[375px] flex-col">
+    <div className="flex h-screen w-full max-w-[430px] flex-col">
       <BackHeader />
 
       {/* 인증수단 선택 */}
@@ -121,7 +121,7 @@ const VerificationPage = () => {
             />
           )}
           <button
-            className="text-lab1-sb flex h-9 w-[343px] cursor-pointer items-center justify-center rounded-[4px] border border-gray-600 py-[10px] text-gray-800"
+            className="text-lab1-sb flex h-9 w-full max-w-[398px] cursor-pointer items-center justify-center rounded-[4px] border border-gray-600 py-[10px] text-gray-800"
             onClick={() => fileInputRef.current?.click()}
           >
             + 사진 업로드

--- a/src/app/mypage/support/faq/page.tsx
+++ b/src/app/mypage/support/faq/page.tsx
@@ -33,7 +33,7 @@ const FaqPage = () => {
   };
 
   return (
-    <div className="max-w-[375px] pb-15">
+    <div className="w-full max-w-[430px] pb-15">
       <BackHeader />
       <div className="flex gap-2 px-4 pt-4 pb-2">
         {(["서비스 이용", "뷰잉"] as const).map(category => (

--- a/src/components/common/AlertMessage.tsx
+++ b/src/components/common/AlertMessage.tsx
@@ -16,7 +16,7 @@ const AlertMessage = ({ message, onDone, className }: AlertMessageProps) => {
 
   return (
     <div
-      className={`text-mint-light text-lab1-sb fixed left-1/2 z-50 w-[343px] -translate-x-1/2 rounded-sm bg-gray-900 px-4 py-1 text-center ${className}`}
+      className={`text-mint-light text-lab1-sb fixed left-1/2 z-50 w-full max-w-[398px] -translate-x-1/2 rounded-sm bg-gray-900 px-4 py-1 text-center ${className}`}
     >
       {message}
     </div>

--- a/src/components/common/BottomActionBar.tsx
+++ b/src/components/common/BottomActionBar.tsx
@@ -30,14 +30,14 @@ const BottomActionBar = ({
   // 단일 버튼 케이스
   if (isSingle) {
     return (
-      <div className="fixed bottom-0 left-1/2 z-[50] flex w-[375px] -translate-x-1/2 flex-col items-center bg-white">
+      <div className="fixed bottom-0 left-1/2 z-[50] flex w-full max-w-[430px] -translate-x-1/2 flex-col items-center bg-white">
         {showDivider && (
           <div className="h-[1px] w-full self-center bg-gray-300" />
         )}
         <button
           type="button"
           onClick={onClick}
-          className={`text-heading3 my-2 w-[343px] rounded py-3 transition ${
+          className={`text-heading3 my-2 w-[calc(100%-32px)] max-w-[398px] rounded py-3 transition ${
             disabled
               ? "cursor-not-allowed bg-gray-300 text-white"
               : variant === "outline"
@@ -53,11 +53,11 @@ const BottomActionBar = ({
 
   // 버튼 두 개 이상 케이스
   return (
-    <div className="fixed bottom-0 left-1/2 z-[50] flex w-[375px] -translate-x-1/2 flex-col items-center bg-white">
+    <div className="fixed bottom-0 left-1/2 z-[50] flex w-full max-w-[430px] -translate-x-1/2 flex-col items-center bg-white">
       {showDivider && <div className="h-[1px] w-full bg-gray-300" />}
 
       <div
-        className={`my-2 flex w-[343px] ${
+        className={`my-2 flex w-[calc(100%-32px)] max-w-[398px] ${
           layout === "equal" ? "gap-2.5" : "gap-1"
         }`}
       >

--- a/src/components/common/ImagePreviewSection.tsx
+++ b/src/components/common/ImagePreviewSection.tsx
@@ -68,7 +68,7 @@ const ImagePreviewSection = ({
   return (
     <div
       className={clsx(
-        "scrollbar-hide max-w-[375px] overflow-x-auto",
+        "scrollbar-hide w-full max-w-[430px] overflow-x-auto",
         wrapperClassName,
       )}
     >

--- a/src/components/common/InputField.tsx
+++ b/src/components/common/InputField.tsx
@@ -40,7 +40,7 @@ const InputField = React.forwardRef<HTMLInputElement, InputFieldProps>(
         </span>
 
         <div className="flex flex-col gap-2">
-          <div className="flex max-w-[343px] gap-1">
+          <div className="flex w-full max-w-[398px] gap-1">
             <input
               name={props.name ?? "default-input"}
               ref={ref}

--- a/src/components/common/ModalLayout.tsx
+++ b/src/components/common/ModalLayout.tsx
@@ -33,7 +33,7 @@ const ModalLayout = ({
     <div className="fixed inset-0 z-999 flex items-center justify-center bg-gray-800/60">
       <div
         ref={modalRef}
-        className={`relative w-[343px] rounded-lg bg-white ${className}`}
+        className={`relative w-[calc(100%-32px)] max-w-[398px] rounded-lg bg-white ${className}`}
       >
         {!hideCloseButton && (
           <button

--- a/src/components/common/SearchField.tsx
+++ b/src/components/common/SearchField.tsx
@@ -141,7 +141,7 @@ const SearchField = ({
           {label}
         </label>
       )}
-      <div className="flex max-w-[343px] flex-col">
+      <div className="flex w-full max-w-[398px] flex-col">
         <div className="group relative w-full">
           <input
             id="search-input"

--- a/src/components/common/UserRoomPreview.tsx
+++ b/src/components/common/UserRoomPreview.tsx
@@ -2,6 +2,8 @@ import Image from "next/image";
 
 import clsx from "clsx";
 
+import { DEFAULT_PROFILE_IMAGES } from "@/utils/images/getRandomDefaultProfile";
+
 type UserRoomPreviewVariant = "sm" | "md" | "lg";
 
 interface UserRoomPreviewProps {
@@ -58,7 +60,7 @@ const UserRoomPreview = ({
       }}
     >
       <Image
-        src={userImg}
+        src={userImg || DEFAULT_PROFILE_IMAGES[0]}
         alt="유저 이미지"
         width={size}
         height={size}
@@ -74,7 +76,7 @@ const UserRoomPreview = ({
       />
 
       <Image
-        src={roomImg}
+        src={roomImg || "/svgs/common/room-img.svg"}
         alt="룸 이미지"
         width={size}
         height={size}

--- a/src/components/common/calendar/TimeSpinner.tsx
+++ b/src/components/common/calendar/TimeSpinner.tsx
@@ -118,28 +118,32 @@ const TimeSpinner = ({
   };
 
   return (
-    <div className="relative z-30 flex w-full justify-center gap-3 border-b border-gray-200 bg-white py-3">
-      <WheelColumn
-        ref={hourRef}
-        items={HOURS}
-        selected={hour}
-        onClick={handleHourChange}
-        debounceScroll={() => debounceScroll(hourTimer, hourSnap.snap)}
-        type="hour"
-        containerClassName="w-[72px]"
-      />
-      <div className="border-mint-contrast pointer-events-none absolute top-1/2 left-[92px] z-20 h-[50px] w-[72px] -translate-y-1/2 border-y" />
+    <div className="relative z-30 mx-auto flex w-full max-w-[360px] justify-center gap-3 border-b border-gray-200 bg-white py-3">
+      <div className="relative">
+        <WheelColumn
+          ref={hourRef}
+          items={HOURS}
+          selected={hour}
+          onClick={handleHourChange}
+          debounceScroll={() => debounceScroll(hourTimer, hourSnap.snap)}
+          type="hour"
+          containerClassName="w-[72px]"
+        />
+        <div className="border-mint-contrast pointer-events-none absolute top-1/2 left-1/2 z-20 h-[50px] w-[72px] -translate-x-1/2 -translate-y-1/2 border-y" />
+      </div>
 
-      <WheelColumn
-        ref={minuteRef}
-        items={MINUTES}
-        selected={minute}
-        onClick={handleMinuteChange}
-        debounceScroll={() => debounceScroll(minuteTimer, minuteSnap.snap)}
-        type="minute"
-        containerClassName="w-[72px]"
-      />
-      <div className="border-mint-contrast pointer-events-none absolute top-1/2 left-[176px] z-20 h-[50px] w-[72px] -translate-y-1/2 border-y" />
+      <div className="relative">
+        <WheelColumn
+          ref={minuteRef}
+          items={MINUTES}
+          selected={minute}
+          onClick={handleMinuteChange}
+          debounceScroll={() => debounceScroll(minuteTimer, minuteSnap.snap)}
+          type="minute"
+          containerClassName="w-[72px]"
+        />
+        <div className="border-mint-contrast pointer-events-none absolute top-1/2 left-1/2 z-20 h-[50px] w-[72px] -translate-x-1/2 -translate-y-1/2 border-y" />
+      </div>
     </div>
   );
 };

--- a/src/components/home/AddListingFab.tsx
+++ b/src/components/home/AddListingFab.tsx
@@ -2,13 +2,32 @@
 
 import { useRouter } from "next/navigation";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import PlusIcon from "@/public/svgs/common/plus-icon.svg";
 
 const AddListingFab = () => {
   const router = useRouter();
   const [hovered, setHovered] = useState(false);
+  const [translateX, setTranslateX] = useState<string>("");
+
+  useEffect(() => {
+    const updateTransform = () => {
+      const screenW = window.innerWidth;
+      const maxWidth = Math.min(screenW, 430);
+      const half = maxWidth / 2;
+
+      // 최소 180px 기준 ~ 최대 215px 기준 사이에서 대응
+      const clampedHalf = Math.max(180, Math.min(half, 215));
+      const offset = clampedHalf - 20;
+
+      setTranslateX(`calc(${offset}px - 100%)`);
+    };
+
+    updateTransform(); // 초기 실행
+    window.addEventListener("resize", updateTransform);
+    return () => window.removeEventListener("resize", updateTransform);
+  }, []);
 
   return (
     <button
@@ -16,9 +35,12 @@ const AddListingFab = () => {
       onClick={() => router.push("/listings/create/redirect")}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
-      className={`bg-mint shadow-fab active:bg-mint-contrast fixed bottom-23.5 left-1/2 z-10 flex h-13.5 cursor-pointer items-center rounded-full text-white transition-all duration-500 ${
+      className={`bg-mint shadow-fab active:bg-mint-contrast fixed bottom-23.5 left-1/2 z-50 flex h-13.5 cursor-pointer items-center rounded-full text-white transition-all duration-500 ${
         hovered ? "px-4" : "px-[15px]"
-      } translate-x-[calc(187.5px-100%-20px)]`}
+      }`}
+      style={{
+        transform: `translateX(${translateX})`,
+      }}
     >
       <PlusIcon className="h-6 w-6 text-white" />
       <span

--- a/src/components/home/ViewingSection.tsx
+++ b/src/components/home/ViewingSection.tsx
@@ -54,7 +54,7 @@ const ViewingSection = () => {
         <span className="text-heading3 px-4 text-gray-900">
           다가오는 뷰잉 일정
         </span>
-        <div className="mx-4 mt-1 flex w-[343px]">
+        <div className="mx-4 mt-1 flex">
           <span className="bg-mint-light border-mint text-mint text-lab1-sb flex h-10 w-full items-center justify-center rounded border">
             로그인 후 이용할 수 있습니다
           </span>
@@ -71,7 +71,7 @@ const ViewingSection = () => {
         다가오는 뷰잉 일정
       </span>
 
-      <div className="scrollbar-hide flex w-full max-w-[375px] gap-1 overflow-x-auto px-4">
+      <div className="scrollbar-hide flex w-full max-w-[430px] gap-1 overflow-x-auto px-4">
         {filteredData && filteredData.length > 0 ? (
           filteredData.map(viewing => {
             const day = dayjs.utc(viewing.meetingDay).tz(dayjs.tz.guess());

--- a/src/components/home/filter/BudgetSlider.tsx
+++ b/src/components/home/filter/BudgetSlider.tsx
@@ -39,9 +39,9 @@ const BudgetSlider = ({
       </div>
 
       <div className="relative flex w-full flex-col justify-center gap-2 px-4 py-1">
-        <div className="absolute top-4 left-4 z-0 h-1 w-[343px] rounded-full bg-gray-100" />
+        <div className="absolute top-4 left-4 z-0 h-1 w-full max-w-[398px] rounded-full bg-gray-100" />
 
-        <div className="w-[327px] self-center pt-[6px] pb-7">
+        <div className="w-full max-w-[382px] min-w-[327px] self-center pt-[6px] pb-7">
           <Slider
             range
             className="custom-slider my-[1px]"

--- a/src/components/home/filter/RoomTypeSelector.tsx
+++ b/src/components/home/filter/RoomTypeSelector.tsx
@@ -16,7 +16,7 @@ const RoomTypeSelector = ({
   return (
     <div className="flex items-center gap-3 py-4">
       <span className="text-heading3 px-4 py-2 text-gray-900">매물유형</span>
-      <div className="flex w-fit max-w-[269px] flex-wrap items-center gap-2 px-4 py-2">
+      <div className="flex w-fit max-w-[324px] min-w-[269px] flex-wrap items-center gap-2 px-4 py-2">
         {ROOM_TYPES.map(type => (
           <SelectableChip
             key={type}

--- a/src/components/home/filter/SubwayStationSelector.tsx
+++ b/src/components/home/filter/SubwayStationSelector.tsx
@@ -77,7 +77,7 @@ const SubwayStationSelector = ({
           <div className="absolute top-2 left-0 z-0 h-1 w-full -translate-y-1/2 rounded-full bg-gray-100" />
           <div className="bg-mint absolute top-2 left-0 z-10 h-1 w-[5%] -translate-y-1/2 rounded-full transition-all duration-200" />
 
-          <div className="w-[327px] pb-[30px]">
+          <div className="w-full max-w-[382px] min-w-[327px] pb-[30px]">
             <Slider
               className="custom-slider my-[1px]"
               value={localRadiusKm}

--- a/src/components/home/filterBar/FilterBar.tsx
+++ b/src/components/home/filterBar/FilterBar.tsx
@@ -87,7 +87,7 @@ const FilterBar = () => {
 
   return (
     <div className="mb-3 flex w-full items-center gap-3 py-2">
-      <div className="scrollbar-hide flex max-w-[329px] gap-1 overflow-x-auto pl-4">
+      <div className="scrollbar-hide flex w-[calc(100%-46px)] max-w-[384px] gap-1 overflow-x-auto pl-4">
         {sortedFilters.map(({ label, value }) => (
           <FilterChip
             key={label}

--- a/src/components/layout/LayoutWrapper.tsx
+++ b/src/components/layout/LayoutWrapper.tsx
@@ -42,7 +42,7 @@ const LayoutWrapper = ({ children }: { children: React.ReactNode }) => {
       className={
         isAdmin
           ? "min-h-screen w-full overflow-y-auto bg-white"
-          : "scrollbar-hide mx-auto h-screen max-w-[480px] min-w-[375px] overflow-y-auto"
+          : "scrollbar-hide mx-auto h-screen w-full max-w-[430px] overflow-y-auto"
       }
     >
       <Suspense fallback={null}>

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import ReservationTooltip from "@/components/reservation/ReservationTooltip";
 
@@ -23,6 +23,9 @@ const TabBar = () => {
   const pathname = usePathname();
   const [showViewingTooltip, setShowViewingTooltip] = useState(false);
 
+  const [, setTooltipLeft] = useState(0);
+  const viewingTabRef = useRef<HTMLLIElement>(null);
+
   useEffect(() => {
     const shouldShow = sessionStorage.getItem("showViewingTooltip");
     if (shouldShow === "true") {
@@ -35,19 +38,35 @@ const TabBar = () => {
     }
   }, []);
 
+  useEffect(() => {
+    const handleResize = () => {
+      if (viewingTabRef.current) {
+        const rect = viewingTabRef.current.getBoundingClientRect();
+        setTooltipLeft(rect.left);
+      }
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   return (
-    <nav className="fixed bottom-0 left-1/2 z-20 max-w-[480px] min-w-[375px] -translate-x-1/2 border-t border-gray-200 bg-white py-[6px]">
+    <nav className="fixed bottom-0 left-1/2 z-20 w-full max-w-[430px] -translate-x-1/2 border-t border-gray-200 bg-white py-[6px]">
       <ul className="flex justify-between">
         {tabs.map(({ href, label, icon }) => {
           const isActive = pathname === href;
           const colorClass = isActive ? "text-gray-900" : "text-gray-400";
 
+          const isViewingTab = href === "/viewing";
+
           return (
             <li
               key={href}
+              ref={isViewingTab ? viewingTabRef : undefined}
               className="relative flex h-[49px] w-1/4 items-center justify-center text-center"
             >
-              {href === "/home" && showViewingTooltip && (
+              {isViewingTab && showViewingTooltip && pathname === "/home" && (
                 <ReservationTooltip message="방금 예약한 뷰잉을 확인할 수 있어요" />
               )}
 

--- a/src/components/layout/header/BackHeader.tsx
+++ b/src/components/layout/header/BackHeader.tsx
@@ -32,7 +32,7 @@ const BackHeader = ({
   return (
     <header
       className={clsx(
-        "sticky top-0 left-1/2 z-50 flex h-12 max-w-[480px] min-w-[375px] items-center justify-between px-4 py-3",
+        "sticky top-0 z-50 flex h-12 w-full max-w-[430px] items-center justify-between px-4 py-3",
         className || "bg-white",
       )}
     >

--- a/src/components/layout/header/MainHeader.tsx
+++ b/src/components/layout/header/MainHeader.tsx
@@ -28,7 +28,7 @@ const MainHeader = () => {
   };
 
   return (
-    <header className="bg-gray-0 sticky top-0 left-1/2 z-50 flex h-12 max-w-[480px] min-w-[375px] items-center justify-between px-4 py-3">
+    <header className="bg-gray-0 sticky top-0 left-1/2 z-50 flex h-12 w-full max-w-[430px] items-center justify-between px-4 py-3">
       <button onClick={() => router.push("/home")} className="cursor-pointer">
         <MainLogo className="h-[18px] w-[126px]" />
       </button>

--- a/src/components/layout/header/TitleHeader.tsx
+++ b/src/components/layout/header/TitleHeader.tsx
@@ -8,7 +8,7 @@ interface TitleHeaderProps {
 
 const TitleHeader = ({ title, rightIcon, onRightClick }: TitleHeaderProps) => {
   return (
-    <header className="sticky top-0 left-1/2 z-50 flex h-12 max-w-[480px] min-w-[375px] items-center justify-between bg-white px-4 py-3">
+    <header className="sticky top-0 left-1/2 z-50 flex h-12 w-full max-w-[430px] items-center justify-between bg-white px-4 py-3">
       {title ? (
         <h1 className="text-heading2 flex-grow text-center text-gray-900">
           {title}

--- a/src/components/listings/AddressMap.tsx
+++ b/src/components/listings/AddressMap.tsx
@@ -15,7 +15,7 @@ const AddressMap = ({ region, isReservationConfirmed }: AddressMapProps) => {
   return (
     <div className="flex flex-col gap-3">
       {/* 지도 */}
-      <div className="relative h-[343px] w-[343px] overflow-hidden">
+      <div className="relative aspect-square h-full max-h-[398px] w-full max-w-[398px] overflow-hidden">
         <GoogleMap lat={region.latitude} lng={region.longitude} />
 
         {!isReservationConfirmed && (
@@ -29,7 +29,7 @@ const AddressMap = ({ region, isReservationConfirmed }: AddressMapProps) => {
 
       {/* 주소 정보 */}
       {isReservationConfirmed && (
-        <div className="bg-gray-0 text-body1-sb flex max-w-[343px] flex-col gap-2 rounded p-2 text-gray-900">
+        <div className="bg-gray-0 text-body1-sb flex w-full max-w-[398px] flex-col gap-2 rounded p-2 text-gray-900">
           <p> {formatAddress(region)}</p>
           <p>unit. {region.unit}</p>
         </div>

--- a/src/components/listings/BottomSheet.tsx
+++ b/src/components/listings/BottomSheet.tsx
@@ -74,7 +74,7 @@ const BottomSheet = ({
 
       {/* 바텀시트 */}
       <div
-        className={`fixed bottom-0 left-1/2 z-[100] w-[375px] -translate-x-1/2 rounded-t-2xl border border-gray-500 bg-white pt-3 transition-transform duration-300 ease-in-out ${
+        className={`fixed bottom-0 left-1/2 z-[100] w-full max-w-[430px] -translate-x-1/2 rounded-t-2xl border border-gray-500 bg-white pt-3 transition-transform duration-300 ease-in-out ${
           isOpen ? "translate-y-0" : "translate-y-full"
         }`}
         onClick={e => e.stopPropagation()}

--- a/src/components/listings/ImageSlider.tsx
+++ b/src/components/listings/ImageSlider.tsx
@@ -16,11 +16,12 @@ const ImageSlider = ({ photoUrls }: ImageSliderProps) => {
   const [currentIndex, setCurrentIndex] = useState(1);
 
   return (
-    <div className="relative h-[375px] w-[375px]">
+    <div className="relative aspect-square w-full max-w-[430px] overflow-hidden">
       {/* 슬라이드 카운터 UI */}
       <div className="text-cap1-med absolute bottom-5 left-6 z-10 flex items-center gap-1 rounded-[50px] bg-gray-800/60 px-2 py-1 text-gray-200">
-        <span> {currentIndex}</span>
-        <span>/</span> <span>{photoUrls.length}</span>
+        <span>{currentIndex}</span>
+        <span>/</span>
+        <span>{photoUrls.length}</span>
       </div>
 
       <Swiper
@@ -32,15 +33,14 @@ const ImageSlider = ({ photoUrls }: ImageSliderProps) => {
         className="h-full w-full"
       >
         {photoUrls.map((url, idx) => (
-          <SwiperSlide key={idx}>
+          <SwiperSlide key={idx} className="relative h-full w-full">
             <Image
               src={url}
               alt={`매물 이미지 ${idx + 1}`}
-              width={375}
-              height={375}
+              fill
               unoptimized
-              className="h-full w-full border border-gray-200 object-cover"
               priority={idx === 0}
+              className="border border-gray-200 object-cover"
             />
           </SwiperSlide>
         ))}

--- a/src/components/listings/create/addressPhoto/AddressField.tsx
+++ b/src/components/listings/create/addressPhoto/AddressField.tsx
@@ -178,7 +178,7 @@ const AddressField = ({ onNext, edit }: AddressFieldProps) => {
         <div className="flex flex-col gap-2">
           <div
             className={clsx(
-              "flex h-11 w-[343px] items-center justify-between rounded-[4px] border px-4 py-3",
+              "flex h-11 w-full max-w-[398px] items-center justify-between rounded-[4px] border px-4 py-3",
               getBorderColor(addressData.streetName, isFocused),
             )}
           >
@@ -209,7 +209,7 @@ const AddressField = ({ onNext, edit }: AddressFieldProps) => {
                 {suggestions.map(item => (
                   <li
                     key={item.placeId}
-                    className="text-cap1-med cursor-pointer truncate max-w-[343px] px-4 py-2 text-gray-700 hover:bg-gray-100"
+                    className="text-cap1-med w-full max-w-[398px] cursor-pointer truncate px-4 py-2 text-gray-700 hover:bg-gray-100"
                     onMouseDown={e => {
                       e.preventDefault(); // prevent input blur
                       handleSelectSuggestion(item.placeId, item.text);
@@ -233,7 +233,7 @@ const AddressField = ({ onNext, edit }: AddressFieldProps) => {
         </div>
 
         {isSearchClicked && selectedAddress && (
-          <div className="h-[343px] w-[343px] py-3">
+          <div className="aspect-square h-full max-h-[398px] min-h-[343px] w-full max-w-[398px] py-3">
             <GoogleMap
               lat={selectedAddress.latitude}
               lng={selectedAddress.longitude}
@@ -278,7 +278,7 @@ const AddressField = ({ onNext, edit }: AddressFieldProps) => {
                   <div className="text-body2-med text-gray-700">Unit No.</div>
                   <div
                     className={clsx(
-                      "flex h-11 w-[343px] items-center rounded-[4px] border px-4 py-3",
+                      "flex h-11 w-full max-w-[398px] items-center rounded-[4px] border px-4 py-3",
                       getBorderColor(addressData.unit, isUnitFocused),
                     )}
                   >
@@ -302,7 +302,7 @@ const AddressField = ({ onNext, edit }: AddressFieldProps) => {
                   </div>
                   <div
                     className={clsx(
-                      "flex h-11 w-[343px] items-center rounded-[4px] border px-4 py-3",
+                      "flex h-11 w-full max-w-[398px] items-center rounded-[4px] border px-4 py-3",
                       getBorderColor(
                         addressData.buildingName,
                         isBuildingFocused,

--- a/src/components/listings/create/addressPhoto/BottomSheet.tsx
+++ b/src/components/listings/create/addressPhoto/BottomSheet.tsx
@@ -30,10 +30,10 @@ const BottomSheet = ({ onClose }: BottomSheetProps) => {
       />
       {/* 바텀시트 */}
       <div
-        className={`fixed bottom-0 left-1/2 z-110 w-[375px] -translate-x-1/2 rounded-t-2xl border border-gray-500 bg-white transition-transform duration-500 ease-in-out ${isOpen ? "translate-y-0" : "translate-y-full"} `}
+        className={`fixed bottom-0 left-1/2 z-110 w-full max-w-[430px] -translate-x-1/2 rounded-t-2xl border border-gray-500 bg-white transition-transform duration-500 ease-in-out ${isOpen ? "translate-y-0" : "translate-y-full"} `}
         onClick={e => e.stopPropagation()}
       >
-        <div className="flex flex-col gap-4 px-5 pt-3">
+        <div className="mx-auto flex w-[328px] flex-col justify-center gap-4 pt-3">
           <div className="flex justify-center">
             <div className="h-1 w-[53px] rounded-[50px] bg-gray-500" />
           </div>

--- a/src/components/listings/create/addressPhoto/PhotoField.tsx
+++ b/src/components/listings/create/addressPhoto/PhotoField.tsx
@@ -100,7 +100,7 @@ const PhotoField = ({ onNext, edit = false }: PhotoFieldProps) => {
   };
 
   return (
-    <div className="max-w-[375px] pb-[70px]">
+    <div className="w-full max-w-[430px] pb-[70px]">
       <div className="flex flex-col gap-2">
         <div className="text-heading3 p-4 text-gray-900">
           직접 촬영한 매물 사진을 올려주세요
@@ -127,7 +127,7 @@ const PhotoField = ({ onNext, edit = false }: PhotoFieldProps) => {
             </div>
           </div>
           <div
-            className="bg-mint-light text-mint text-lab1-sb flex h-9 w-full max-w-[343px] cursor-pointer items-center justify-center rounded-[4px] border"
+            className="bg-mint-light text-mint text-lab1-sb flex h-9 w-full max-w-[398px] cursor-pointer items-center justify-center rounded-[4px] border"
             onClick={handleClickUpload}
           >
             + 매물 사진 올리기

--- a/src/components/listings/create/common/DropdownOptionsList.tsx
+++ b/src/components/listings/create/common/DropdownOptionsList.tsx
@@ -9,15 +9,14 @@ function DropdownOptionsList<T extends string | number>({
   value,
   onSelect,
 }: DropdownOptionsListProps<T>) {
-
   return (
     <ul className="flex flex-col gap-3 px-4 py-3">
       {options.map(({ value: val, label }) => {
-         const isSelected = val === value;
+        const isSelected = val === value;
         return (
           <li
             key={String(val)}
-            className={`text-lab1-sb flex w-[343px] cursor-pointer items-center justify-center rounded-[4px] border py-[10px] ${
+            className={`text-lab1-sb flex w-full max-w-[398px] cursor-pointer items-center justify-center rounded-[4px] border py-[10px] ${
               isSelected
                 ? "border-mint bg-mint-light text-mint"
                 : "border-gray-600 text-gray-800"

--- a/src/components/listings/create/common/DropdownSelector.tsx
+++ b/src/components/listings/create/common/DropdownSelector.tsx
@@ -21,7 +21,7 @@ const DropdownSelector = ({
     <>
       <div
         className={clsx(
-          "flex h-19 w-[375px] cursor-pointer items-start justify-between p-4",
+          "flex h-19 w-full max-w-[430px] cursor-pointer items-start justify-between p-4",
           isOpen && "mb-1",
         )}
         onClick={onClick}

--- a/src/components/listings/create/contractTerms/CostDetailField.tsx
+++ b/src/components/listings/create/contractTerms/CostDetailField.tsx
@@ -63,7 +63,7 @@ const CostDetailField = ({
           <input
             type="text"
             placeholder="입력해주세요"
-            className={`placeholder:text-body2-med h-9 w-[343px] rounded-[4px] border border-gray-400 px-4 py-3 placeholder:text-gray-500 focus:outline-none ${value.weeklyCost ? "border-gray-600 text-gray-900" : "border-gray-400"}`}
+            className={`placeholder:text-body2-med h-9 w-full max-w-[398px] rounded-[4px] border border-gray-400 px-4 py-3 placeholder:text-gray-500 focus:outline-none ${value.weeklyCost ? "border-gray-600 text-gray-900" : "border-gray-400"}`}
             value={value.weeklyCost === 0 ? "" : value.weeklyCost}
             onChange={e => handleInputChange("weeklyCost", +e.target.value)}
           />
@@ -90,7 +90,7 @@ const CostDetailField = ({
       <div className="flex flex-col gap-4">
         <div className="text-body1-sb text-gray-800">빌에 포함된 항목</div>
 
-        <div className="flex w-[343px] flex-wrap content-center items-center gap-2 self-stretch">
+        <div className="flex w-full max-w-[398px] flex-wrap content-center items-center gap-2 self-stretch">
           {CATEGORY_OPTIONS[4].items.map(({ optionId, label }) => {
             const isSelected = optionItemIds.includes(optionId);
             return (
@@ -111,7 +111,7 @@ const CostDetailField = ({
             onChange={e => setCustomIncludedItemText(e.target.value)}
             placeholder="항목을 입력해주세요"
             className={clsx(
-              "text-body2-med h-9 w-[343px] rounded-[4px] border px-4 py-3 text-gray-900 placeholder:text-gray-500 focus:outline-none",
+              "text-body2-med h-9 w-full max-w-[398px] rounded-[4px] border px-4 py-3 text-gray-900 placeholder:text-gray-500 focus:outline-none",
               customIncludedItemText ? "border-gray-600" : "border-gray-400",
             )}
           />
@@ -126,7 +126,7 @@ const CostDetailField = ({
         <input
           type="text"
           placeholder="ex) 주차비는 주/$20 입니다"
-          className={`text-body2-med h-9 w-[343px] rounded-[4px] border px-4 py-3 placeholder:text-gray-500 focus:outline-none ${value.costDescription ? "border-gray-600 text-gray-900" : "border-gray-400"}`}
+          className={`text-body2-med h-9 w-full max-w-[398px] rounded-[4px] border px-4 py-3 placeholder:text-gray-500 focus:outline-none ${value.costDescription ? "border-gray-600 text-gray-900" : "border-gray-400"}`}
           value={value.costDescription}
           onChange={e => handleInputChange("costDescription", e.target.value)}
         />
@@ -134,11 +134,11 @@ const CostDetailField = ({
 
       <Divider className="my-[2px]" />
 
-      <div className="flex gap-2">
+      <div className="flex w-full gap-2">
         {/*디파짓 */}
-        <div className="flex flex-col gap-2">
+        <div className="flex w-1/2 flex-col gap-2">
           <div className="text-body1-sb text-gray-800">디파짓</div>
-          <div className="relative w-[167px]">
+          <div className="relative">
             <input
               type="text"
               placeholder="입력해주세요"
@@ -162,9 +162,9 @@ const CostDetailField = ({
           </button>
         </div>
         {/* key디파짓 */}
-        <div className="flex flex-col gap-2">
+        <div className="flex w-1/2 flex-col gap-2">
           <div className="text-body1-sb text-gray-800">Key 디파짓 (선택)</div>
-          <div className="relative w-[167px]">
+          <div className="relative">
             <input
               type="text"
               placeholder="입력해주세요"

--- a/src/components/listings/create/createConfirm/CreateConfirm.tsx
+++ b/src/components/listings/create/createConfirm/CreateConfirm.tsx
@@ -129,7 +129,7 @@ const CreateConfirm = ({ onNext }: CreateConfirmProps) => {
   const propertyContent = propertyInfo.find(item => item.kind === listingType);
 
   return (
-    <div className="max-w-[375px] pb-[70px]">
+    <div className="w-full max-w-[430px] pb-[70px]">
       <BackHeader rightIcon="close" />
       <TitleSection
         title="입력한 정보를 확인해주세요"

--- a/src/components/listings/create/listingDetails/FurnitureContent.tsx
+++ b/src/components/listings/create/listingDetails/FurnitureContent.tsx
@@ -21,7 +21,7 @@ const FurnitureContent = ({ value, onChange }: FurnitureContentProps) => {
       {Object.entries(furnitureItems).map(([category, items]) => (
         <div key={category} className="flex flex-col gap-3 px-5 py-4">
           <div className="text-body1-sb text-gray-800">{category}</div>
-          <ul className="scrollbar-hide flex max-w-[335px] gap-1 overflow-x-auto">
+          <ul className="scrollbar-hide flex w-full gap-1 overflow-x-auto">
             {items.map(({ optionId, label }) => {
               const Icon = furnitureIconMap[label];
               const isSelected = value.includes(optionId);

--- a/src/components/listings/create/listingDetails/HighLightsContent.tsx
+++ b/src/components/listings/create/listingDetails/HighLightsContent.tsx
@@ -20,7 +20,7 @@ const HighLightsContent = ({ value, onChange }: HighLightsContentProps) => {
   return (
     <div className="flex flex-col gap-3 px-4 py-2">
       <div className="text-lab1-sb text-gray-700">5개 골라주세요</div>
-      <div className="flex w-[343px] flex-wrap content-center items-center gap-3 self-stretch">
+      <div className="flex w-full max-w-[398px] flex-wrap content-center items-center gap-3 self-stretch">
         {highlightOptions.map(({ optionId, label }) => {
           const isSelected = value.includes(optionId);
           return (

--- a/src/components/listings/create/listingDetails/InternalDetailsContent.tsx
+++ b/src/components/listings/create/listingDetails/InternalDetailsContent.tsx
@@ -167,7 +167,7 @@ const InternalDetailsContent = <
       : (value as ShareInternalDetails);
 
   return (
-    <div className="max-w-[375px]">
+    <div className="w-full max-w-[430px]">
       <div className="relative">
         {isOpenAreaInfo && (
           <div
@@ -198,16 +198,19 @@ const InternalDetailsContent = <
         </div>
 
         {/* 면적 입력 */}
-        <div className="flex justify-between">
+        <div className="flex justify-between gap-2">
           {areaKeys.map(key => {
             const rawValue = details[key];
 
             return (
-              <div key={key} className="flex h-[73px] flex-col justify-between">
+              <div
+                key={key}
+                className="flex h-[73px] w-1/2 flex-col justify-between"
+              >
                 <div className="text-body2-med text-gray-600">
                   {LISTING_INFORMATION_LABEL[key]}
                 </div>
-                <div className="relative w-[167px]">
+                <div className="relative">
                   <input
                     type="text"
                     className={`text-body1-med h-11 w-full rounded-[4px] border px-4 py-3 pr-12 focus:outline-none ${
@@ -248,13 +251,13 @@ const InternalDetailsContent = <
             return acc;
           }, [])
           .map((pair, rowIdx) => (
-            <div key={rowIdx} className="flex justify-between px-4 py-5">
+            <div key={rowIdx} className="flex w-full gap-2 px-4 py-5">
               {pair.map(key => (
-                <div key={key} className="flex flex-col">
+                <div key={key} className="flex w-1/2 flex-col">
                   <div className="text-body1-sb mb-3 text-gray-800">
                     {LISTING_INFORMATION_LABEL[key]}
                   </div>
-                  <div className="relative w-[167px]">
+                  <div className="relative">
                     {(() => {
                       const rawValue = details[key as keyof typeof details];
                       const valueForInput =

--- a/src/components/listings/create/movingConditions/LivingConditionsContent.tsx
+++ b/src/components/listings/create/movingConditions/LivingConditionsContent.tsx
@@ -32,7 +32,7 @@ const LivingConditionsContent = ({
   };
 
   return (
-    <div className="max-w-[375px]">
+    <div className="w-full max-w-[430px]">
       <div className="flex gap-2 px-4 py-2">
         {firstLineKeys.map(option => (
           <div key={option} className="flex flex-1 flex-col gap-2">

--- a/src/components/listings/detailShow/CategoryContent.tsx
+++ b/src/components/listings/detailShow/CategoryContent.tsx
@@ -42,7 +42,7 @@ const CategoryContent = ({
   value,
   listingData,
 }: CategoryContentProps) => {
-  const baseClass = "text-body2-med w-[319px] text-right text-gray-600";
+  const baseClass = "text-body2-med max-w-[384px] text-right text-gray-600";
 
   switch (keyName) {
     case "kind":

--- a/src/components/listings/shared/HostDescriptionSection.tsx
+++ b/src/components/listings/shared/HostDescriptionSection.tsx
@@ -15,7 +15,7 @@ const HostDescriptionSection = ({
   <Section withDivider={false}>
     <div className="flex flex-col gap-3 px-4 py-3">
       <Label>호스트 설명</Label>
-      <div className="flex max-w-[343px] flex-col gap-4">
+      <div className="flex w-full max-w-[398px] flex-col gap-4">
         <div className="text-body2-med flex rounded bg-gray-200 px-2 py-3 break-words whitespace-normal text-gray-700">
           {description}
         </div>

--- a/src/components/login/GoogleLoginButton.tsx
+++ b/src/components/login/GoogleLoginButton.tsx
@@ -25,7 +25,7 @@ const GoogleLoginButton = () => {
     <button
       type="button"
       onClick={handleGoogleLogin}
-      className="flex h-12 w-[343px] cursor-pointer items-center justify-center gap-1 rounded-sm border border-gray-500 bg-white py-[10px]"
+      className="flex h-12 w-full max-w-[398px] min-w-[343px] cursor-pointer items-center justify-center gap-1 rounded-sm border border-gray-500 bg-white py-[10px]"
     >
       <GoogleIcon />
       <span className="text-body1-sb text-gray-900">

--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -13,7 +13,7 @@ const NotificationCard = ({ id, title, content, isRead }: NotificationItem) => {
   return (
     <div
       onClick={handleClick}
-      className="flex h-fit w-[343px] cursor-pointer flex-col gap-1 rounded-lg bg-white p-4"
+      className="flex h-fit w-full max-w-[398px] cursor-pointer flex-col gap-1 rounded-lg bg-white p-4"
     >
       {!isRead && <div className="bg-red h-2 w-2 rounded-full" />}
       <p className="text-body1-sb text-gray-900">{title}</p>

--- a/src/components/notification/NotificationToast.tsx
+++ b/src/components/notification/NotificationToast.tsx
@@ -17,7 +17,7 @@ const NotificationToast = ({
   }, [onClose]);
 
   return (
-    <div className="border-mint bg-mint-light shadow-fab w-[343px] rounded-lg border p-4">
+    <div className="border-mint bg-mint-light shadow-fab w-[calc(100%-32px)] max-w-[398px] rounded-lg border p-4">
       <div className="text-body1-sb text-mint-contrast">{title}</div>
       {content && (
         <div className="text-cap1-med mt-1 text-gray-600">{content}</div>

--- a/src/components/reservation/ReservationTooltip.tsx
+++ b/src/components/reservation/ReservationTooltip.tsx
@@ -6,7 +6,7 @@ interface ReservationTooltipProps {
 
 const ReservationTooltip = ({ message }: ReservationTooltipProps) => {
   return (
-    <div className="absolute -top-16 left-[143px] flex flex-col items-center">
+    <div className="absolute -top-16 left-1/2 z-50 flex translate-x-[calc(-50%+3px)] flex-col items-center">
       <div className="text-cap1-med rounded bg-gray-800 p-3 whitespace-nowrap text-gray-300">
         {message}
       </div>

--- a/src/components/skeleton/home/ViewingSectionSkeleton.tsx
+++ b/src/components/skeleton/home/ViewingSectionSkeleton.tsx
@@ -22,7 +22,7 @@ const ViewingSectionSkeleton = () => {
         다가오는 뷰잉 일정
       </span>
 
-      <div className="scrollbar-hide flex w-full max-w-[375px] gap-1 overflow-x-auto px-4">
+      <div className="scrollbar-hide flex w-full max-w-[430px] gap-1 overflow-x-auto px-4">
         {[...Array(3)].map((_, idx) => (
           <ViewingBoxSkeleton key={idx} />
         ))}

--- a/src/components/skeleton/listingsDetail/ListingContentSkeleton.tsx
+++ b/src/components/skeleton/listingsDetail/ListingContentSkeleton.tsx
@@ -2,7 +2,7 @@ const ListingContentSkeleton = () => {
   return (
     <div className="pointer-events-none">
       {/* 이미지 영역 */}
-      <div className="h-[375px] w-[375px] animate-pulse bg-gray-200" />
+      <div className="h-full max-h-[430px] min-h-[375px] w-full max-w-[430px] animate-pulse bg-gray-200" />
 
       {/* 프로필 영역 */}
       <div className="flex items-center gap-[14px] border-b border-gray-200 px-4 py-3">

--- a/src/components/skeleton/listingsDetail/ListingDetailLoadingSkeleton.tsx
+++ b/src/components/skeleton/listingsDetail/ListingDetailLoadingSkeleton.tsx
@@ -52,7 +52,7 @@ const ListingDetailLoadingSkeleton = ({
         <div className="mt-6 mb-15">
           <div className="flex flex-col gap-3 px-4 py-8">
             <span className="text-heading3 text-gray-900">위치</span>
-            <div className="flex h-[343px] w-[343px] items-center justify-center">
+            <div className="flex h-full max-h-[398px] min-h-[343px] w-full max-w-[398px] items-center justify-center">
               <span className="text-heading3 text-gray-600">
                 상세 주소는 뷰잉 예약 후 확인 가능합니다.
               </span>

--- a/src/components/skeleton/listingsDetail/ListingDetailSkeleton.tsx
+++ b/src/components/skeleton/listingsDetail/ListingDetailSkeleton.tsx
@@ -61,8 +61,8 @@ const ListingDetailSkeleton = () => {
       <Section withDivider={false}>
         <div className="flex flex-col gap-3 px-4 py-3">
           <Label>호스트 설명</Label>
-          <div className="flex max-w-[343px] flex-col gap-4">
-            <div className="h-[79px] w-[343px] rounded bg-gray-200" />
+          <div className="flex w-full max-w-[398px] flex-col gap-4">
+            <div className="h-[79px] w-full max-w-[398px] rounded bg-gray-200" />
             <div className="flex gap-2">
               {[...Array(3)].map((_, idx) => (
                 <div

--- a/src/components/terms/TermsDetailTemplate.tsx
+++ b/src/components/terms/TermsDetailTemplate.tsx
@@ -19,7 +19,7 @@ const TermsDetailTemplate = ({
   bottomText,
 }: TermsDetailTemplateProps) => {
   return (
-    <div className="flex max-w-[375px] flex-col gap-4">
+    <div className="flex w-full max-w-[430px] flex-col gap-4">
       <BackHeader />
 
       {/* 타이틀 영역 */}

--- a/src/components/viewings/ViewingSaveButton.tsx
+++ b/src/components/viewings/ViewingSaveButton.tsx
@@ -4,7 +4,7 @@ interface ViewingSaveButtonProps {
 
 const ViewingSaveButton = ({ onClick }: ViewingSaveButtonProps) => {
   return (
-    <div className="fixed bottom-0 left-1/2 z-100 flex w-[375px] -translate-x-1/2 flex-col items-center bg-white px-4 py-3">
+    <div className="fixed bottom-0 left-1/2 z-100 flex w-full max-w-[430px] -translate-x-1/2 flex-col items-center bg-white px-4 py-3">
       <button
         onClick={onClick}
         className="border-mint-contrast text-heading3 text-mint-contrast hover:bg-mint-light w-full cursor-pointer rounded border p-3"

--- a/src/constants/funnel-steps.ts
+++ b/src/constants/funnel-steps.ts
@@ -1,11 +1,11 @@
 export const FUNNEL_FLOW = [
   { step: "listingType" },
-  // {
-  //   step: "addressPhoto",
-  //   subSteps: ["address", "photo"],
-  // },
-  // { step: "listingDetails" },
-  // { step: "movingConditions" },
+  {
+    step: "addressPhoto",
+    subSteps: ["address", "photo"],
+  },
+  { step: "listingDetails" },
+  { step: "movingConditions" },
   { step: "contractTerms" },
   { step: "listingDescription" },
   { step: "createConfirm" },

--- a/src/hooks/common/useMultipleImageUpload.ts
+++ b/src/hooks/common/useMultipleImageUpload.ts
@@ -69,9 +69,13 @@ const useMultipleImageUpload = ({
     }
 
     try {
-      const fileExtensions = validFiles.map(file => file.type.split("/")[1]);
+      const fileExtensions = validFiles.map(file => {
+        const ext = file.name.split(".").pop();
+        if (!ext) throw new Error("파일 확장자를 추출할 수 없습니다.");
+        return ext;
+      });
       const presignedUrls = await getPresignedUrls(fileExtensions);
-     
+
       await uploadFilesToPresignedUrls(validFiles, presignedUrls);
       const uploadedUrls = presignedUrls.map(p => p.fileUrl);
       setPreviewUrls(prev => [...prev, ...uploadedUrls]);


### PR DESCRIPTION
### 🔥 작업 내용
- 전체 레이아웃을 max-width 기준으로 재정렬했습니다.
- 기존에는 375px 기준으로 너비가 고정되어 있었으나, 해당 스타일을 모두 제거하고,
  Figma처럼 375px 기반으로 작업하되 최대 너비는 430px로 지정하여  
  화면이 줄어들어도 레이아웃이 깨지지 않도록 수정했습니다.

### 🔗 이슈
- #119 
