### PR TITLE
📡 API : 매물등록 단계 임시저장 처리 api연동

### DIFF
--- a/src/apis/propertyApi.ts
+++ b/src/apis/propertyApi.ts
@@ -9,7 +9,7 @@ import {
   SummaryProperty,
 } from "@/types/property.type";
 import { FilteredPropertyParams } from "@/types/property.type";
-import { TemporaryProperty } from "@/types/temporaryProperty.type";
+import { TemporaryPropertyPost } from "@/types/temporaryProperty.type";
 
 import { axiosInstance } from "./axios";
 
@@ -164,7 +164,9 @@ export const fetchTemporaryPropertyData = async (
 };
 
 //임시저장 매물 등록
-export const postTemporaryPropertyData = async (payload: TemporaryProperty) => {
+export const postTemporaryPropertyData = async (
+  payload: Partial<TemporaryPropertyPost>,
+) => {
   const { data } = await axiosInstance.post(
     "/api/v1/temporary-properties",
     payload,

--- a/src/app/listings/[id]/edit/listingDetails/page.tsx
+++ b/src/app/listings/[id]/edit/listingDetails/page.tsx
@@ -212,7 +212,6 @@ const ListingDetailsEdit = () => {
     }
 
     if (payload) {
-      console.log(payload);
       patchProperty(payload, {
         onSuccess: () => {
           router.push(`/listings/${id}/edit`);

--- a/src/app/listings/[id]/edit/page.tsx
+++ b/src/app/listings/[id]/edit/page.tsx
@@ -46,8 +46,7 @@ const ListingsEdit = () => {
   if (isLoading) return <div>로딩 중...</div>;
   if (error || !originalDetail || !currentDetail)
     return <div>데이터를 불러올 수 없습니다.</div>;
-  console.log(originalDetail);
-  // console.log("바뀐값: ", currentDetail);
+
   return (
     <>
       <div className="w-full max-w-[430px] pb-[130px]">

--- a/src/app/listings/draft/page.tsx
+++ b/src/app/listings/draft/page.tsx
@@ -24,7 +24,6 @@ const ListingDraft = () => {
       try {
         const data = await getTemporaryPropertyId();
         setTemporaryProperties(data); // 성공 시 상태 저장
-        console.log(data);
       } catch (error) {
         console.error("임시 저장 매물 조회 실패:", error);
       }

--- a/src/app/listings/draft/page.tsx
+++ b/src/app/listings/draft/page.tsx
@@ -9,6 +9,7 @@ import { getTemporaryPropertyId } from "@/apis/propertyApi";
 import { formatMeetingDay } from "@/utils/formatter/dateFormatter";
 
 import BackHeader from "@/components/layout/header/BackHeader";
+import { FUNNEL_STEPS_MAP } from "@/constants/funnel-steps";
 
 import { TemporaryPropertyId } from "@/types/temporaryProperty.type";
 
@@ -33,8 +34,12 @@ const ListingDraft = () => {
   }, []);
 
   const handleClick = (property: TemporaryPropertyId) => {
+    const lastStepItem = FUNNEL_STEPS_MAP.find(
+      step => step.key === property.status,
+    );
+    const lastStep = lastStepItem?.label ?? "addressPhoto";
     router.push(
-      `/listings/create?step=listingType&draftId=${property.temporaryPropertyId}`,
+      `/listings/create?step=${lastStep}&draftId=${property.temporaryPropertyId}`,
     );
   };
 

--- a/src/components/layout/header/BackHeader.tsx
+++ b/src/components/layout/header/BackHeader.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import clsx from "clsx";
+
+import { useFunnel } from "@/hooks/common/useFunnel";
+
+import { FUNNEL_FLOW } from "@/constants/funnel-steps";
 
 import CloseIcon from "@/public/svgs/common/close-icon.svg";
 import BackArrow from "@/public/svgs/common/left-arrow.svg";
@@ -28,6 +32,24 @@ const BackHeader = ({
   className,
 }: BackHeaderProps) => {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const draftId = searchParams.get("draftId");
+
+  const { onPrevStep } = useFunnel({ steps: FUNNEL_FLOW });
+
+  const handleBack = () => {
+    if (onBackClick) {
+      onBackClick();
+    } else if (draftId) {
+      onPrevStep();
+    } else {
+      if (window.history.length > 1) {
+        router.back();
+      } else {
+        router.push("/home");
+      }
+    }
+  };
 
   return (
     <header
@@ -39,19 +61,7 @@ const BackHeader = ({
       {hideBackIcon ? (
         <div className="w-6" />
       ) : (
-        <button
-          onClick={
-            onBackClick ??
-            (() => {
-              if (window.history.length > 1) {
-                router.back();
-              } else {
-                router.push("/home");
-              }
-            })
-          }
-          className="cursor-pointer"
-        >
+        <button onClick={handleBack} className="cursor-pointer">
           <BackArrow className="h-6 w-6" />
         </button>
       )}

--- a/src/components/listings/create/addressPhoto/PhotoField.tsx
+++ b/src/components/listings/create/addressPhoto/PhotoField.tsx
@@ -23,7 +23,8 @@ import BottomActionBar from "@/components/common/BottomActionBar";
 import Divider from "@/components/common/Divider";
 import ImageSlider from "@/components/listings/detailShow/ImageSlider";
 import ImageAlertModal from "@/components/signup/profile/ImageAlertModal";
-import { TemporaryProperty } from "@/types/temporaryProperty.type";
+
+import { TemporaryPropertyPost } from "@/types/temporaryProperty.type";
 
 import QuestionMarkIcon from "@/public/svgs/listings/question-mark-icon.svg";
 
@@ -44,7 +45,7 @@ const PhotoField = ({ onNext, edit = false }: PhotoFieldProps) => {
   const searchParams = useSearchParams();
   const draftId = searchParams.get("draftId");
 
-  const { photoUrls, setPhotoUrls } = useListingStore();
+  const { listingType, region, photoUrls, setPhotoUrls } = useListingStore();
 
   const [previewUrls, setPreviewUrls] = useState<string[]>(photoUrls); // 이미지 URL 미리보기
   const [, setUploadedFiles] = useState<File[]>([]); // 실제 파일 객체
@@ -53,7 +54,9 @@ const PhotoField = ({ onNext, edit = false }: PhotoFieldProps) => {
   const [showErrorModal, setShowErrorModal] = useState(false);
   const [, setAlertMessage] = useState<string | null>(null);
 
-  const [draftData, setDraftData] = useState<TemporaryProperty | null>(null);
+  const [draftData, setDraftData] = useState<TemporaryPropertyPost | null>(
+    null,
+  );
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -114,20 +117,29 @@ const PhotoField = ({ onNext, edit = false }: PhotoFieldProps) => {
   }, [draftId, edit]);
 
   const handleTemporarySave = async () => {
-    if (!draftData) return;
+    let payload;
 
-    const payload = {
-      jsonDiscriminator: draftData.kind,
-      ...draftData,
-      photoUrls,
-    };
+    if (draftData) {
+      payload = {
+        ...draftData,
+        kind: listingType ?? draftData.kind,
+        jsonDiscriminator: listingType ?? draftData.kind,
+        region,
+        photoUrls,
+      };
+    } else {
+      payload = {
+        kind: listingType ?? undefined,
+        jsonDiscriminator: listingType ?? undefined,
+        region,
+        photoUrls,
+      };
+    }
 
     try {
       await postTemporaryPropertyData(payload);
-      console.log(payload)
-      router.push(
-        `/listings/create?step=addressPhoto&draftId=${draftId}&subStep=photo`,
-      );
+      console.log(payload);
+      router.push(`/home`);
     } catch (e) {
       console.error("임시 저장 실패:", e);
     }

--- a/src/components/listings/create/addressPhoto/PhotoField.tsx
+++ b/src/components/listings/create/addressPhoto/PhotoField.tsx
@@ -105,7 +105,6 @@ const PhotoField = ({ onNext, edit = false }: PhotoFieldProps) => {
       try {
         const draftData = await fetchTemporaryPropertyData(Number(draftId));
         setDraftData(draftData);
-        console.log(draftData);
         if (Array.isArray(draftData.photoUrls)) {
           setPhotoUrls(draftData.photoUrls); // Zustand store에 저장
           setPreviewUrls(draftData.photoUrls); // 미리보기에도 반영
@@ -123,7 +122,6 @@ const PhotoField = ({ onNext, edit = false }: PhotoFieldProps) => {
 
     try {
       await postTemporaryPropertyData(payload);
-      console.log(payload);
       router.push(`/home`);
     } catch (e) {
       console.error("임시 저장 실패:", e);
@@ -139,7 +137,6 @@ const PhotoField = ({ onNext, edit = false }: PhotoFieldProps) => {
       jsonDiscriminator,
       photoUrls,
     };
-    console.log(payload);
     patchProperty(payload, {
       onSuccess: () => {
         router.push(`/listings/${id}/edit`);

--- a/src/components/listings/create/addressPhoto/PhotoField.tsx
+++ b/src/components/listings/create/addressPhoto/PhotoField.tsx
@@ -11,6 +11,7 @@ import {
 import { getPropertyPresignedUrl } from "@/apis/s3UploadApi";
 
 import useMultipleImageUpload from "@/hooks/common/useMultipleImageUpload";
+import { createPayloadByStep } from "@/hooks/property/createPayloadBySteps";
 import {
   usePatchProperty,
   usePropertyDetailEditList,
@@ -45,7 +46,8 @@ const PhotoField = ({ onNext, edit = false }: PhotoFieldProps) => {
   const searchParams = useSearchParams();
   const draftId = searchParams.get("draftId");
 
-  const { listingType, region, photoUrls, setPhotoUrls } = useListingStore();
+  const store = useListingStore();
+  const { photoUrls, setPhotoUrls } = store;
 
   const [previewUrls, setPreviewUrls] = useState<string[]>(photoUrls); // 이미지 URL 미리보기
   const [, setUploadedFiles] = useState<File[]>([]); // 실제 파일 객체
@@ -117,24 +119,7 @@ const PhotoField = ({ onNext, edit = false }: PhotoFieldProps) => {
   }, [draftId, edit]);
 
   const handleTemporarySave = async () => {
-    let payload;
-
-    if (draftData) {
-      payload = {
-        ...draftData,
-        kind: listingType ?? draftData.kind,
-        jsonDiscriminator: listingType ?? draftData.kind,
-        region,
-        photoUrls,
-      };
-    } else {
-      payload = {
-        kind: listingType ?? undefined,
-        jsonDiscriminator: listingType ?? undefined,
-        region,
-        photoUrls,
-      };
-    }
+    const payload = createPayloadByStep("ADDRESS_PHOTO", store, draftData);
 
     try {
       await postTemporaryPropertyData(payload);

--- a/src/components/listings/create/contractTerms/ContractTermsLayout.tsx
+++ b/src/components/listings/create/contractTerms/ContractTermsLayout.tsx
@@ -150,7 +150,6 @@ const ContractTerms = ({ onNext }: ContractTermsProps) => {
             );
             store.setOptionItemIds(optionItemIds);
           }
-          console.log("contract", draftData);
         }
       } catch (error) {
         console.error("임시 저장 데이터 가져오기 실패", error);
@@ -268,10 +267,8 @@ const ContractTerms = ({ onNext }: ContractTermsProps) => {
     const payload = createPayloadByStep("CONTRACT_TERMS", store, draftData);
     try {
       await postTemporaryPropertyData(payload);
-      console.log("임시저장post:", payload);
       router.push(`/home`);
     } catch (e) {
-      console.log(payload);
       console.error("임시 저장 실패:", e);
     }
   };

--- a/src/components/listings/create/contractTerms/ContractTermsLayout.tsx
+++ b/src/components/listings/create/contractTerms/ContractTermsLayout.tsx
@@ -1,6 +1,16 @@
+import { useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
+
 import { useEffect, useState } from "react";
 
 import { useListingStore } from "@/stores/useListingStore";
+
+import {
+  fetchTemporaryPropertyData,
+  postTemporaryPropertyData,
+} from "@/apis/propertyApi";
+
+import { createPayloadByStep } from "@/hooks/property/createPayloadBySteps";
 
 import {
   convertUtcStringToLocalTime,
@@ -16,6 +26,8 @@ import FunnelLayout from "@/components/listings/create/common/FunnelLayout";
 import { COMMON_CONTRACT_TERMS } from "@/constants/question-map";
 
 import { ContractTermsOption } from "@/types/createPropertyAnswer.type";
+import { OptionItem } from "@/types/listingDetailGet.type";
+import { TemporaryPropertyPost } from "@/types/temporaryProperty.type";
 
 import ContractTermsContent from "./ContractTermsContent";
 
@@ -29,13 +41,25 @@ const ContractTerms = ({ onNext }: ContractTermsProps) => {
     Record<string, ContractTermsOption>
   >({});
   const [alertMessage, setAlertMessage] = useState<string | null>(null);
-  const costDetails = useListingStore(state => state.costDetails);
-  const timeSlots = useListingStore(state => state.timeSlots);
-  const meetingDateFrom = useListingStore(state => state.meetingDateFrom);
-  const meetingDateTo = useListingStore(state => state.meetingDateTo);
-  const optionItemIds = useListingStore(state => state.optionItemIds);
-  const viewingAlwaysAvailable = useListingStore(
-    state => state.viewingAlwaysAvailable,
+
+  const store = useListingStore();
+  const {
+    costDetails,
+    timeSlots,
+    meetingDateFrom,
+    meetingDateTo,
+    optionItemIds,
+    viewingAlwaysAvailable,
+    setAllCostDetails,
+    setMeetingDateRange,
+    setViewingAlwaysAvailable,
+    setTimeSlots,
+  } = store;
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const draftId = searchParams.get("draftId");
+  const [draftData, setDraftData] = useState<TemporaryPropertyPost | null>(
+    null,
   );
 
   const { openIndices, visibleIndices, toggleIndex, autoAdvance } =
@@ -54,7 +78,7 @@ const ContractTerms = ({ onNext }: ContractTermsProps) => {
           );
         }
         if (id === "timeSlots") {
-          return timeSlots.length > 0;
+          return !!(timeSlots && timeSlots.length > 0);
         }
         return !!selectedAnswers[id];
       },
@@ -81,7 +105,7 @@ const ContractTerms = ({ onNext }: ContractTermsProps) => {
         }, 4000);
       }
     } else if (id === "timeSlots") {
-      if (timeSlots.length > 0) {
+      if (timeSlots && timeSlots.length > 0) {
         timer = setTimeout(() => {
           autoAdvance(currentIndex);
         }, 4000);
@@ -106,6 +130,38 @@ const ContractTerms = ({ onNext }: ContractTermsProps) => {
     viewingAlwaysAvailable,
     timeSlots,
   ]);
+
+  useEffect(() => {
+    const initDraft = async () => {
+      if (!draftId) return;
+      try {
+        const draftData = await fetchTemporaryPropertyData(Number(draftId));
+        setDraftData(draftData);
+
+        if (draftData) {
+          if (draftData.costDetails) setAllCostDetails(draftData.costDetails);
+          if (draftData.meetingDateFrom && draftData.meetingDateTo)
+            setMeetingDateRange(
+              draftData.meetingDateFrom,
+              draftData.meetingDateTo,
+            );
+          if (draftData.viewingAlwaysAvailable)
+            setViewingAlwaysAvailable(draftData.viewingAlwaysAvailable);
+          if (draftData.timeSlots) setTimeSlots(draftData.timeSlots);
+          if (draftData.optionItems) {
+            const optionItemIds = draftData.optionItems.map(
+              (item: OptionItem) => item.optionItemId,
+            );
+            store.setOptionItemIds(optionItemIds);
+          }
+          console.log("contract", draftData);
+        }
+      } catch (error) {
+        console.error("임시 저장 데이터 가져오기 실패", error);
+      }
+    };
+    initDraft();
+  }, [draftId]);
 
   const handleSelect = (id: string, value: ContractTermsOption) => {
     setSelectedAnswers(prev => ({
@@ -132,6 +188,7 @@ const ContractTerms = ({ onNext }: ContractTermsProps) => {
     }
     if (item.id === "timeSlots") {
       return (
+        timeSlots &&
         timeSlots.length > 0 &&
         timeSlots.some(
           slot => !(slot.timeFrom === null || slot.timeTo === null),
@@ -178,6 +235,7 @@ const ContractTerms = ({ onNext }: ContractTermsProps) => {
       }
 
       case "timeSlots": {
+        if (!timeSlots) return "";
         const parts = [];
         for (const slot of timeSlots) {
           if (
@@ -210,6 +268,16 @@ const ContractTerms = ({ onNext }: ContractTermsProps) => {
     }
   };
 
+  const handleTemporarySave = async () => {
+    const payload = createPayloadByStep("CONTRACT_TERMS", store, draftData);
+    try {
+      await postTemporaryPropertyData(payload);
+      console.log("임시저장post:", payload);
+      router.push(`/home`);
+    } catch (e) {
+      console.error("임시 저장 실패:", e);
+    }
+  };
   return (
     <FunnelLayout>
       {COMMON_CONTRACT_TERMS.map((item, index) => (
@@ -237,15 +305,7 @@ const ContractTerms = ({ onNext }: ContractTermsProps) => {
           buttons={[
             {
               label: "저장",
-              onClick: () => {
-                console.log(
-                  costDetails,
-                  meetingDateFrom,
-                  meetingDateTo,
-                  viewingAlwaysAvailable,
-                  timeSlots,
-                );
-              },
+              onClick: handleTemporarySave,
               variant: "outline",
               disabled: !allAnswered,
             },

--- a/src/components/listings/create/contractTerms/ContractTermsLayout.tsx
+++ b/src/components/listings/create/contractTerms/ContractTermsLayout.tsx
@@ -50,10 +50,6 @@ const ContractTerms = ({ onNext }: ContractTermsProps) => {
     meetingDateTo,
     optionItemIds,
     viewingAlwaysAvailable,
-    setAllCostDetails,
-    setMeetingDateRange,
-    setViewingAlwaysAvailable,
-    setTimeSlots,
   } = store;
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -139,15 +135,15 @@ const ContractTerms = ({ onNext }: ContractTermsProps) => {
         setDraftData(draftData);
 
         if (draftData) {
-          if (draftData.costDetails) setAllCostDetails(draftData.costDetails);
+          if (draftData.costDetails) store.setAllCostDetails(draftData.costDetails);
           if (draftData.meetingDateFrom && draftData.meetingDateTo)
-            setMeetingDateRange(
+            store.setMeetingDateRange(
               draftData.meetingDateFrom,
               draftData.meetingDateTo,
             );
           if (draftData.viewingAlwaysAvailable)
-            setViewingAlwaysAvailable(draftData.viewingAlwaysAvailable);
-          if (draftData.timeSlots) setTimeSlots(draftData.timeSlots);
+            store.setViewingAlwaysAvailable(draftData.viewingAlwaysAvailable);
+          if (draftData.timeSlots) store.setTimeSlots(draftData.timeSlots);
           if (draftData.optionItems) {
             const optionItemIds = draftData.optionItems.map(
               (item: OptionItem) => item.optionItemId,
@@ -275,6 +271,7 @@ const ContractTerms = ({ onNext }: ContractTermsProps) => {
       console.log("임시저장post:", payload);
       router.push(`/home`);
     } catch (e) {
+      console.log(payload);
       console.error("임시 저장 실패:", e);
     }
   };

--- a/src/components/listings/create/contractTerms/TimeSlotField.tsx
+++ b/src/components/listings/create/contractTerms/TimeSlotField.tsx
@@ -10,7 +10,7 @@ import { PERIODS, PERIOD_LIMITS } from "@/constants/time-options";
 import { TimeSlot } from "@/types/listingDetailPost.type";
 
 interface TimeSlotFieldProps {
-  value: TimeSlot[];
+  value: TimeSlot[] | null;
   onChange: (updated: TimeSlot[]) => void;
 }
 
@@ -68,7 +68,7 @@ const TimeSlotField = ({ value, onChange }: TimeSlotFieldProps) => {
               <button
                 key="start"
                 className={`text-body1-med flex h-[33px] w-[77px] items-center justify-center gap-1 rounded-[4px] border px-3 py-1 ${getButtonClass(
-                  slots[idx].timeFrom,
+                  slots[idx].timeFrom ,
                   activeSpinner?.period === period &&
                     activeSpinner?.type === "start",
                 )}`}

--- a/src/components/listings/create/createConfirm/CreateConfirm.tsx
+++ b/src/components/listings/create/createConfirm/CreateConfirm.tsx
@@ -226,7 +226,6 @@ const CreateConfirm = ({ onNext }: CreateConfirmProps) => {
     const payload = createPayloadByStep("CREATE_CONFIRM", store, draftData);
     try {
       await postTemporaryPropertyData(payload);
-      console.log("임시저장post:", payload);
       router.push(`/home`);
     } catch (e) {
       console.error("임시 저장 실패:", e);

--- a/src/components/listings/create/createConfirm/CreateConfirm.tsx
+++ b/src/components/listings/create/createConfirm/CreateConfirm.tsx
@@ -54,7 +54,8 @@ const CreateConfirm = ({ onNext }: CreateConfirmProps) => {
       !moveInInfo ||
       (!viewingAlwaysAvailable && (!meetingDateFrom || !meetingDateTo)) ||
       !genderPreference ||
-      !livingConditions
+      !livingConditions ||
+      !timeSlots
     )
       return null;
 

--- a/src/components/listings/create/createConfirm/CreateConfirm.tsx
+++ b/src/components/listings/create/createConfirm/CreateConfirm.tsx
@@ -1,6 +1,18 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { useEffect, useState } from "react";
+
 import { useListingStore } from "@/stores/useListingStore";
 
+import {
+  fetchTemporaryPropertyData,
+  postTemporaryPropertyData,
+} from "@/apis/propertyApi";
+
 import { useMyInfo } from "@/hooks/member/useMemberApi";
+import { createPayloadByStep } from "@/hooks/property/createPayloadBySteps";
 import { usePostProperty } from "@/hooks/property/usePropertyApi";
 
 import BottomActionBar from "@/components/common/BottomActionBar";
@@ -11,7 +23,13 @@ import TitleSection from "@/components/listings/detailShow/TitleSection";
 
 import { propertyInfo } from "@/constants/mock/listing-detail-dummies";
 
+import { OptionItem } from "@/types/listingDetailGet.type";
 import { PropertyDetail } from "@/types/listingDetailPost.type";
+import {
+  RentInternalDetails,
+  ShareInternalDetails,
+} from "@/types/listingDetailPost.type";
+import { TemporaryPropertyPost } from "@/types/temporaryProperty.type";
 
 interface CreateConfirmProps {
   onNext: () => void;
@@ -19,6 +37,18 @@ interface CreateConfirmProps {
 }
 
 const CreateConfirm = ({ onNext }: CreateConfirmProps) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const draftId = searchParams.get("draftId");
+
+  const store = useListingStore();
+  const { mutate: postProperty } = usePostProperty();
+  const { data: myInfo, isLoading } = useMyInfo();
+
+  const [draftData, setDraftData] = useState<TemporaryPropertyPost | null>(
+    null,
+  );
+
   const {
     listingType,
     region,
@@ -40,12 +70,76 @@ const CreateConfirm = ({ onNext }: CreateConfirmProps) => {
     lgbtAvailable,
     moveInInfo,
     livingConditions,
-  } = useListingStore();
+  } = store;
 
-  const { mutate: postProperty } = usePostProperty();
-  const { data: myInfo, isLoading } = useMyInfo();
+  useEffect(() => {
+    const initDraft = async () => {
+      if (!draftId) return;
+      try {
+        const draftData = await fetchTemporaryPropertyData(Number(draftId));
+        setDraftData(draftData);
+        if (draftData) {
+          // listingType 세팅
+          if (draftData.kind === "RENT") store.setListingType("RENT");
+          else if (draftData.kind === "SHARE") store.setListingType("SHARE");
+          // SubType 세팅
+          if (draftData.rentPropertySubType)
+            store.setRentPropertyType(draftData.rentPropertySubType);
+          if (draftData.sharePropertySubType)
+            store.setSharePropertyType(draftData.sharePropertySubType);
 
-  if (isLoading || !myInfo) return null;
+          // Capacity 세팅
+          if (draftData.capacityRent)
+            store.setRentCapacityPeople(draftData.capacityRent);
+          if (draftData.capacityShare)
+            store.setShareCapacityPeople(draftData.capacityShare);
+
+          // internalDetails는 kind에 따라 분기해서 세팅
+          if (draftData.internalDetails) {
+            if (draftData.kind === "RENT") {
+              store.setRentInternalDetails(
+                draftData.internalDetails as RentInternalDetails,
+              );
+            } else if (draftData.kind === "SHARE") {
+              store.setShareInternalDetails(
+                draftData.internalDetails as ShareInternalDetails,
+              );
+            }
+          }
+          // optionItems가 있을 경우 optionItemIds 추출해 세팅
+          if (draftData.optionItems) {
+            const optionItemIds = draftData.optionItems.map(
+              (item: OptionItem) => item.optionItemId,
+            );
+            store.setOptionItemIds(optionItemIds);
+          }
+          if (draftData.moveInInfo) store.setMoveInInfo(draftData.moveInInfo);
+          if (draftData.genderPreference)
+            store.setGenderPreference(draftData.genderPreference);
+          if (draftData.lgbtAvailable)
+            store.setLgbtAvailable(draftData.lgbtAvailable);
+          if (draftData.livingConditions)
+            store.setLivingConditions(draftData.livingConditions);
+        }
+        if (draftData?.description) {
+          store.setDescription(draftData.description);
+        }
+        if (draftData.costDetails)
+          store.setAllCostDetails(draftData.costDetails);
+        if (draftData.meetingDateFrom && draftData.meetingDateTo)
+          store.setMeetingDateRange(
+            draftData.meetingDateFrom,
+            draftData.meetingDateTo,
+          );
+        if (draftData.viewingAlwaysAvailable)
+          store.setViewingAlwaysAvailable(draftData.viewingAlwaysAvailable);
+        if (draftData.timeSlots) store.setTimeSlots(draftData.timeSlots);
+      } catch (error) {
+        console.error("임시 저장 데이터 가져오기 실패", error);
+      }
+    };
+    initDraft();
+  }, [draftId, store]);
 
   const getPayload = (): PropertyDetail | null => {
     if (
@@ -128,7 +222,20 @@ const CreateConfirm = ({ onNext }: CreateConfirmProps) => {
     });
   };
 
+  const handleTemporarySave = async () => {
+    const payload = createPayloadByStep("CREATE_CONFIRM", store, draftData);
+    try {
+      await postTemporaryPropertyData(payload);
+      console.log("임시저장post:", payload);
+      router.push(`/home`);
+    } catch (e) {
+      console.error("임시 저장 실패:", e);
+    }
+  };
+
   const propertyContent = propertyInfo.find(item => item.kind === listingType);
+
+  if (isLoading || !myInfo) return null;
 
   return (
     <div className="w-full max-w-[430px] pb-[70px]">
@@ -143,9 +250,7 @@ const CreateConfirm = ({ onNext }: CreateConfirmProps) => {
         buttons={[
           {
             label: "저장",
-            onClick: () => {
-              console.log(payload);
-            },
+            onClick: handleTemporarySave,
             variant: "outline",
           },
           {

--- a/src/components/listings/create/createConfirm/CreateConfirm.tsx
+++ b/src/components/listings/create/createConfirm/CreateConfirm.tsx
@@ -51,6 +51,7 @@ const CreateConfirm = ({ onNext }: CreateConfirmProps) => {
     if (
       !myInfo ||
       !listingType ||
+      !moveInInfo ||
       (!viewingAlwaysAvailable && (!meetingDateFrom || !meetingDateTo)) ||
       !genderPreference ||
       !livingConditions

--- a/src/components/listings/create/listingDescription/ListingDescription.tsx
+++ b/src/components/listings/create/listingDescription/ListingDescription.tsx
@@ -1,11 +1,17 @@
 "use client";
 
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 
 import { useEffect, useRef, useState } from "react";
 
 import { useListingStore } from "@/stores/useListingStore";
 
+import {
+  fetchTemporaryPropertyData,
+  postTemporaryPropertyData,
+} from "@/apis/propertyApi";
+
+import { createPayloadByStep } from "@/hooks/property/createPayloadBySteps";
 import {
   usePatchProperty,
   usePropertyDetailEditList,
@@ -18,6 +24,8 @@ import BottomActionBar from "@/components/common/BottomActionBar";
 import TextareaField from "@/components/common/TextareaField";
 import BackHeader from "@/components/layout/header/BackHeader";
 
+import { TemporaryPropertyPost } from "@/types/temporaryProperty.type";
+
 interface ListingDescriptionProps {
   onNext?: () => void;
   onPrev?: () => void;
@@ -27,15 +35,22 @@ const ListingDescription = ({
   onNext,
   edit = false,
 }: ListingDescriptionProps) => {
+  const store = useListingStore();
   const router = useRouter();
   const params = useParams();
+  const searchParams = useSearchParams();
+
   const id = params.id as string;
   const { data } = usePropertyDetailEditList(id ?? "");
+  const draftId = searchParams.get("draftId");
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { description, setDescription } = useListingStore();
   const [text, setText] = useState(description || "");
   const [alertMessage, setAlertMessage] = useState<string | null>(null);
+  const [draftData, setDraftData] = useState<TemporaryPropertyPost | null>(
+    null,
+  );
   useEffect(() => {
     if (edit && data) {
       const parsed = toPostPropertyDetail(data);
@@ -46,6 +61,23 @@ const ListingDescription = ({
       setText(description || "");
     }
   }, [edit, data]);
+
+  useEffect(() => {
+    const initDraft = async () => {
+      if (!draftId) return;
+      try {
+        const draftData = await fetchTemporaryPropertyData(Number(draftId));
+        setDraftData(draftData);
+        if (draftData.description) {
+          store.setDescription(draftData.description);
+        }
+        console.log("임시저장get:", draftData);
+      } catch (error) {
+        console.error("임시 저장 데이터 가져오기 실패", error);
+      }
+    };
+    initDraft();
+  }, [draftId, setDescription]);
 
   const handleResize = () => {
     const textarea = textareaRef.current;
@@ -77,6 +109,23 @@ const ListingDescription = ({
       },
     });
   };
+
+  const handleTemporarySave = async () => {
+    const payload = createPayloadByStep(
+      "LISTING_DESCRIPTION",
+      store,
+      draftData,
+    );
+    try {
+      await postTemporaryPropertyData(payload);
+      console.log("임시저장post:", payload);
+      router.push(`/home`);
+    } catch (e) {
+      console.log(payload);
+      console.error("임시 저장 실패:", e);
+    }
+  };
+
   return (
     <>
       <BackHeader rightIcon="close" />
@@ -102,10 +151,7 @@ const ListingDescription = ({
             buttons={[
               {
                 label: "저장",
-                onClick: () => {
-                  setDescription(text);
-                  console.log("저장");
-                },
+                onClick: handleTemporarySave,
                 variant: "outline",
               },
               {

--- a/src/components/listings/create/listingDescription/ListingDescription.tsx
+++ b/src/components/listings/create/listingDescription/ListingDescription.tsx
@@ -71,7 +71,6 @@ const ListingDescription = ({
         if (draftData.description) {
           store.setDescription(draftData.description);
         }
-        console.log("임시저장get:", draftData);
       } catch (error) {
         console.error("임시 저장 데이터 가져오기 실패", error);
       }
@@ -118,10 +117,8 @@ const ListingDescription = ({
     );
     try {
       await postTemporaryPropertyData(payload);
-      console.log("임시저장post:", payload);
       router.push(`/home`);
     } catch (e) {
-      console.log(payload);
       console.error("임시 저장 실패:", e);
     }
   };

--- a/src/components/listings/create/listingDetails/ListingDetailsLayout.tsx
+++ b/src/components/listings/create/listingDetails/ListingDetailsLayout.tsx
@@ -110,7 +110,6 @@ const ListingDetails = ({ onNext }: ListingDetailsProps) => {
           if (draftData.kind === "RENT") store.setListingType("RENT");
           else if (draftData.kind === "SHARE") store.setListingType("SHARE");
         }
-        console.log("임시저장get:", draftData);
       } catch (error) {
         console.error("임시 저장 데이터 가져오기 실패", error);
       }
@@ -169,7 +168,6 @@ const ListingDetails = ({ onNext }: ListingDetailsProps) => {
 
     try {
       await postTemporaryPropertyData(payload);
-      console.log("임시저장post:", payload);
       router.push(`/home`);
     } catch (e) {
       console.error("임시 저장 실패:", e);

--- a/src/components/listings/create/listingDetails/ListingDetailsLayout.tsx
+++ b/src/components/listings/create/listingDetails/ListingDetailsLayout.tsx
@@ -1,8 +1,17 @@
 "use client";
 
+import { useRouter, useSearchParams } from "next/navigation";
+
 import { useEffect, useMemo, useState } from "react";
 
 import { useListingStore } from "@/stores/useListingStore";
+
+import {
+  fetchTemporaryPropertyData,
+  postTemporaryPropertyData,
+} from "@/apis/propertyApi";
+
+import { createPayloadByStep } from "@/hooks/property/createPayloadBySteps";
 
 import {
   LISTING_DETAILS_IDS,
@@ -20,6 +29,7 @@ import FunnelLayout from "@/components/listings/create/common/FunnelLayout";
 import { QUESTION_MAP } from "@/constants/question-map";
 
 import { ListingDetailsOption } from "@/types/createPropertyAnswer.type";
+import { OptionItem } from "@/types/listingDetailGet.type";
 import {
   CapacityRent,
   CapacityShare,
@@ -28,6 +38,7 @@ import {
   ShareInternalDetails,
   SharePropertySubType,
 } from "@/types/listingDetailPost.type";
+import { TemporaryPropertyPost } from "@/types/temporaryProperty.type";
 
 import ListingDetailsDropdownContent from "./ListingDetailsDropdownContent";
 
@@ -40,12 +51,72 @@ const ListingDetails = ({ onNext }: ListingDetailsProps) => {
   const store = useListingStore();
   const { listingType, optionItemIds, setOptionItemIds } = store;
 
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const draftId = searchParams.get("draftId");
+  const [draftData, setDraftData] = useState<TemporaryPropertyPost | null>(
+    null,
+  );
+
   const section = "ListingDetails";
   const questions = useMemo(() => {
     return listingType ? QUESTION_MAP[listingType][section] : [];
   }, [listingType, section]);
+
   const [alertMessage, setAlertMessage] = useState<string | null>(null);
   const { highlightIds, furnitureIds, isBrokeredIds } = LISTING_DETAILS_IDS;
+
+  useEffect(() => {
+    const initDraft = async () => {
+      if (!draftId) return;
+      try {
+        const draftData = await fetchTemporaryPropertyData(Number(draftId));
+        setDraftData(draftData);
+        if (draftData) {
+          // SubType 세팅
+          if (draftData.rentPropertySubType)
+            store.setRentPropertyType(draftData.rentPropertySubType);
+          if (draftData.sharePropertySubType)
+            store.setSharePropertyType(draftData.sharePropertySubType);
+
+          // Capacity 세팅
+          if (draftData.capacityRent)
+            store.setRentCapacityPeople(draftData.capacityRent);
+          if (draftData.capacityShare)
+            store.setShareCapacityPeople(draftData.capacityShare);
+
+          // internalDetails는 kind에 따라 분기해서 세팅
+          if (draftData.internalDetails) {
+            if (draftData.kind === "RENT") {
+              store.setRentInternalDetails(
+                draftData.internalDetails as RentInternalDetails,
+              );
+            } else if (draftData.kind === "SHARE") {
+              store.setShareInternalDetails(
+                draftData.internalDetails as ShareInternalDetails,
+              );
+            }
+          }
+
+          // optionItems가 있을 경우 optionItemIds 추출해 세팅
+          if (draftData.optionItems) {
+            const optionItemIds = draftData.optionItems.map(
+              (item: OptionItem) => item.optionItemId,
+            );
+            store.setOptionItemIds(optionItemIds);
+          }
+
+          // listingType 세팅
+          if (draftData.kind === "RENT") store.setListingType("RENT");
+          else if (draftData.kind === "SHARE") store.setListingType("SHARE");
+        }
+        console.log("임시저장get:", draftData);
+      } catch (error) {
+        console.error("임시 저장 데이터 가져오기 실패", error);
+      }
+    };
+    initDraft();
+  }, [draftId]);
 
   const { openIndices, visibleIndices, toggleIndex, autoAdvance } =
     useDropdownAutoManager({
@@ -83,6 +154,8 @@ const ListingDetails = ({ onNext }: ListingDetailsProps) => {
 
   useEffect(() => {
     openIndices.forEach(idx => {
+      const question = questions[idx];
+      if (!question) return; // idx가 유효하지 않으면 무시
       const answer = getAnswerValue(
         questions[idx].id as ListingDetailsOption["type"],
         store,
@@ -90,6 +163,18 @@ const ListingDetails = ({ onNext }: ListingDetailsProps) => {
       if (autoAdvance && answer) autoAdvance(idx);
     });
   }, [openIndices, questions, autoAdvance, store]);
+
+  const handleTemporarySave = async () => {
+    const payload = createPayloadByStep("LISTING_DETAILS", store, draftData);
+
+    try {
+      await postTemporaryPropertyData(payload);
+      console.log("임시저장post:", payload);
+      router.push(`/home`);
+    } catch (e) {
+      console.error("임시 저장 실패:", e);
+    }
+  };
 
   return (
     <FunnelLayout>
@@ -177,17 +262,7 @@ const ListingDetails = ({ onNext }: ListingDetailsProps) => {
           buttons={[
             {
               label: "저장",
-              onClick: () => {
-                console.log("저장된 Zustand 상태", {
-                  rentPropertyType: store.rentPropertyType,
-                  sharePropertyType: store.sharePropertyType,
-                  rentCapacityPeople: store.rentCapacityPeople,
-                  shareCapacityPeople: store.shareCapacityPeople,
-                  rentInternalDetails: store.rentInternalDetails,
-                  shareInternalDetails: store.shareInternalDetails,
-                  optionItemIds,
-                });
-              },
+              onClick: handleTemporarySave,
               variant: "outline",
             },
             {

--- a/src/components/listings/create/listingType/ListingType.tsx
+++ b/src/components/listings/create/listingType/ListingType.tsx
@@ -108,7 +108,7 @@ const ListingType = ({
           {temporaryProperties.map(property => {
             const formatted = formatMeetingDay(property.createdAt);
             const lastStepItem = FUNNEL_STEPS_MAP.find(
-              step => step.key === property.lastStep,
+              step => step.key === property.status,
             );
             const lastStep = lastStepItem?.label ?? "addressPhoto";
             return (

--- a/src/components/listings/create/listingType/ListingType.tsx
+++ b/src/components/listings/create/listingType/ListingType.tsx
@@ -42,7 +42,6 @@ const ListingType = ({
       try {
         const data = await getTemporaryPropertyId();
         setTemporaryProperties(data); // 성공 시 상태 저장
-        console.log(data);
       } catch (error) {
         console.error("임시 저장 매물 조회 실패:", error);
       }

--- a/src/components/listings/create/listingType/ListingType.tsx
+++ b/src/components/listings/create/listingType/ListingType.tsx
@@ -105,26 +105,33 @@ const ListingType = ({
               <LeftArrow />
             </div>
           </div>
-          {temporaryProperties.map(property => {
-            const formatted = formatMeetingDay(property.createdAt);
-            const lastStepItem = FUNNEL_STEPS_MAP.find(
-              step => step.key === property.status,
-            );
-            const lastStep = lastStepItem?.label ?? "addressPhoto";
-            return (
-              <div
-                key={property.temporaryPropertyId}
-                className="text-body2-med cursor-pointer px-4 py-2 text-gray-700"
-                onClick={() =>
-                  router.push(
-                    `/listings/create?step=${lastStep}&draftId=${property.temporaryPropertyId}`,
-                  )
-                }
-              >
-                {formatted.fullDate} {formatted.weekday} {formatted.time}
-              </div>
-            );
-          })}
+          {[...temporaryProperties]
+            .sort(
+              (a, b) =>
+                new Date(b.createdAt).getTime() -
+                new Date(a.createdAt).getTime(),
+            )
+            .slice(0, 3)
+            .map(property => {
+              const formatted = formatMeetingDay(property.createdAt);
+              const lastStepItem = FUNNEL_STEPS_MAP.find(
+                step => step.key === property.status,
+              );
+              const lastStep = lastStepItem?.label ?? "addressPhoto";
+              return (
+                <div
+                  key={property.temporaryPropertyId}
+                  className="text-body2-med cursor-pointer px-4 py-2 text-gray-700"
+                  onClick={() =>
+                    router.push(
+                      `/listings/create?step=${lastStep}&draftId=${property.temporaryPropertyId}`,
+                    )
+                  }
+                >
+                  {formatted.fullDate} {formatted.weekday} {formatted.time}
+                </div>
+              );
+            })}
         </>
       )}
     </>

--- a/src/components/listings/create/movingConditions/MovingConditionLayout.tsx
+++ b/src/components/listings/create/movingConditions/MovingConditionLayout.tsx
@@ -43,7 +43,6 @@ const MovingCondition = ({ onNext }: MovingConditionProps) => {
     moveInInfo,
     livingConditions,
     optionItemIds,
-    setLgbtAvailable,
     setGenderPreference,
     setMoveInInfo,
     setLivingConditions,
@@ -145,13 +144,13 @@ const MovingCondition = ({ onNext }: MovingConditionProps) => {
         const draftData = await fetchTemporaryPropertyData(Number(draftId));
         setDraftData(draftData);
         if (draftData) {
-          if (draftData.moveInInfo) setMoveInInfo(draftData.moveInInfo);
+          if (draftData.moveInInfo) store.setMoveInInfo(draftData.moveInInfo);
           if (draftData.genderPreference)
-            setGenderPreference(draftData.genderPreference);
+            store.setGenderPreference(draftData.genderPreference);
           if (draftData.lgbtAvailable)
-            setLgbtAvailable(draftData.lgbtAvailable);
+            store.setLgbtAvailable(draftData.lgbtAvailable);
           if (draftData.livingConditions)
-            setLivingConditions(draftData.livingConditions);
+            store.setLivingConditions(draftData.livingConditions);
           if (draftData.optionItems) {
             const optionItemIds = draftData.optionItems.map(
               (item: OptionItem) => item.optionItemId,
@@ -301,6 +300,7 @@ const MovingCondition = ({ onNext }: MovingConditionProps) => {
       console.log("임시저장post:", payload);
       router.push(`/home`);
     } catch (e) {
+      console.log("moving", payload)
       console.error("임시 저장 실패:", e);
     }
   };

--- a/src/components/listings/create/movingConditions/MovingConditionLayout.tsx
+++ b/src/components/listings/create/movingConditions/MovingConditionLayout.tsx
@@ -157,7 +157,6 @@ const MovingCondition = ({ onNext }: MovingConditionProps) => {
             );
             store.setOptionItemIds(optionItemIds);
           }
-          console.log("movingget", draftData);
         }
       } catch (error) {
         console.error("임시 저장 데이터 가져오기 실패", error);
@@ -297,10 +296,8 @@ const MovingCondition = ({ onNext }: MovingConditionProps) => {
     const payload = createPayloadByStep("MOVING_CONDITIONS", store, draftData);
     try {
       await postTemporaryPropertyData(payload);
-      console.log("임시저장post:", payload);
       router.push(`/home`);
     } catch (e) {
-      console.log("moving", payload)
       console.error("임시 저장 실패:", e);
     }
   };

--- a/src/components/listings/create/movingConditions/MovingConditionLayout.tsx
+++ b/src/components/listings/create/movingConditions/MovingConditionLayout.tsx
@@ -43,6 +43,7 @@ const MovingCondition = ({ onNext }: MovingConditionProps) => {
     moveInInfo,
     livingConditions,
     optionItemIds,
+    setLgbtAvailable,
     setGenderPreference,
     setMoveInInfo,
     setLivingConditions,
@@ -147,6 +148,8 @@ const MovingCondition = ({ onNext }: MovingConditionProps) => {
           if (draftData.moveInInfo) setMoveInInfo(draftData.moveInInfo);
           if (draftData.genderPreference)
             setGenderPreference(draftData.genderPreference);
+          if (draftData.lgbtAvailable)
+            setLgbtAvailable(draftData.lgbtAvailable);
           if (draftData.livingConditions)
             setLivingConditions(draftData.livingConditions);
           if (draftData.optionItems) {

--- a/src/components/listings/create/movingConditions/MovingConditionLayout.tsx
+++ b/src/components/listings/create/movingConditions/MovingConditionLayout.tsx
@@ -1,8 +1,17 @@
 "use client";
 
+import { useRouter, useSearchParams } from "next/navigation";
+
 import { useEffect, useState } from "react";
 
 import { useListingStore } from "@/stores/useListingStore";
+
+import {
+  fetchTemporaryPropertyData,
+  postTemporaryPropertyData,
+} from "@/apis/propertyApi";
+
+import { createPayloadByStep } from "@/hooks/property/createPayloadBySteps";
 
 import { formatMeetingDay } from "@/utils/formatter/dateFormatter";
 import { useDropdownAutoManager } from "@/utils/listing/create/useDropdownAutoManager";
@@ -17,6 +26,8 @@ import { CATEGORY_OPTIONS } from "@/constants/property-category";
 import { COMMON_MOVING_CONDITIONS } from "@/constants/question-map";
 
 import { MovingConditionsOption } from "@/types/createPropertyAnswer.type";
+import { OptionItem } from "@/types/listingDetailGet.type";
+import { TemporaryPropertyPost } from "@/types/temporaryProperty.type";
 
 import MovingConditionDropdownContent from "./MovingConditionDropdownContent";
 
@@ -26,6 +37,7 @@ interface MovingConditionProps {
 }
 
 const MovingCondition = ({ onNext }: MovingConditionProps) => {
+  const store = useListingStore();
   const {
     genderPreference,
     moveInInfo,
@@ -35,7 +47,14 @@ const MovingCondition = ({ onNext }: MovingConditionProps) => {
     setMoveInInfo,
     setLivingConditions,
     setOptionItemIds,
-  } = useListingStore();
+  } = store;
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const draftId = searchParams.get("draftId");
+  const [draftData, setDraftData] = useState<TemporaryPropertyPost | null>(
+    null,
+  );
   const [alertMessage, setAlertMessage] = useState<string | null>(null);
   const { openIndices, visibleIndices, toggleIndex, autoAdvance } =
     useDropdownAutoManager({
@@ -45,14 +64,10 @@ const MovingCondition = ({ onNext }: MovingConditionProps) => {
         switch (id) {
           case "genderPreference":
             return !!genderPreference;
-          case "additionalInfo":
-            return optionItemIds.length > 0;
+
           case "moveInInfo":
-            return (
-              !!moveInInfo.availableFrom ||
-              !!moveInInfo.immediate ||
-              !!moveInInfo.negotiable
-            );
+            if (!moveInInfo) return false;
+            return !!moveInInfo.availableFrom || !!moveInInfo.availableTo;
           case "livingConditions":
             return (
               !!livingConditions &&
@@ -89,9 +104,8 @@ const MovingCondition = ({ onNext }: MovingConditionProps) => {
         break;
       case "moveInInfo":
         if (
-          moveInInfo.availableFrom ||
-          moveInInfo.immediate ||
-          moveInInfo.negotiable
+          moveInInfo &&
+          (moveInInfo.availableFrom || moveInInfo.availableTo)
         ) {
           timer = setTimeout(() => {
             autoAdvance(currentIndex);
@@ -123,22 +137,32 @@ const MovingCondition = ({ onNext }: MovingConditionProps) => {
     livingConditions,
   ]);
 
-  const handleSelect = (id: string, option: MovingConditionsOption) => {
-    switch (option.type) {
-      case "genderPreference":
-        setGenderPreference(option.value);
-        break;
-      case "optionItemIds":
-        setOptionItemIds(option.value);
-        break;
-      case "moveInInfo":
-        if (option.value) setMoveInInfo(option.value);
-        break;
-      case "livingConditions":
-        setLivingConditions(option.value);
-        break;
-    }
-  };
+  useEffect(() => {
+    const initDraft = async () => {
+      if (!draftId) return;
+      try {
+        const draftData = await fetchTemporaryPropertyData(Number(draftId));
+        setDraftData(draftData);
+        if (draftData) {
+          if (draftData.moveInInfo) setMoveInInfo(draftData.moveInInfo);
+          if (draftData.genderPreference)
+            setGenderPreference(draftData.genderPreference);
+          if (draftData.livingConditions)
+            setLivingConditions(draftData.livingConditions);
+          if (draftData.optionItems) {
+            const optionItemIds = draftData.optionItems.map(
+              (item: OptionItem) => item.optionItemId,
+            );
+            store.setOptionItemIds(optionItemIds);
+          }
+          console.log("movingget", draftData);
+        }
+      } catch (error) {
+        console.error("임시 저장 데이터 가져오기 실패", error);
+      }
+    };
+    initDraft();
+  }, [draftId]);
 
   const allAnswered = COMMON_MOVING_CONDITIONS.every(item => {
     switch (item.id) {
@@ -160,9 +184,7 @@ const MovingCondition = ({ onNext }: MovingConditionProps) => {
       }
       case "moveInInfo":
         return (
-          !!moveInInfo.availableFrom ||
-          !!moveInInfo.immediate ||
-          !!moveInInfo.negotiable
+          !!moveInInfo && !!moveInInfo.availableFrom && !!moveInInfo.availableTo
         );
       case "livingConditions":
         return (
@@ -252,6 +274,34 @@ const MovingCondition = ({ onNext }: MovingConditionProps) => {
     }
   };
 
+  const handleSelect = (id: string, option: MovingConditionsOption) => {
+    switch (option.type) {
+      case "genderPreference":
+        setGenderPreference(option.value);
+        break;
+      case "optionItemIds":
+        setOptionItemIds(option.value);
+        break;
+      case "moveInInfo":
+        setMoveInInfo(option.value);
+        break;
+      case "livingConditions":
+        setLivingConditions(option.value);
+        break;
+    }
+  };
+
+  const handleTemporarySave = async () => {
+    const payload = createPayloadByStep("MOVING_CONDITIONS", store, draftData);
+    try {
+      await postTemporaryPropertyData(payload);
+      console.log("임시저장post:", payload);
+      router.push(`/home`);
+    } catch (e) {
+      console.error("임시 저장 실패:", e);
+    }
+  };
+
   return (
     <FunnelLayout>
       {COMMON_MOVING_CONDITIONS.map((item, index) => {
@@ -280,14 +330,7 @@ const MovingCondition = ({ onNext }: MovingConditionProps) => {
           buttons={[
             {
               label: "저장",
-              onClick: () => {
-                console.log(
-                  genderPreference,
-                  moveInInfo,
-                  livingConditions,
-                  optionItemIds,
-                );
-              },
+              onClick: handleTemporarySave,
               variant: "outline",
             },
             {

--- a/src/constants/time-options.ts
+++ b/src/constants/time-options.ts
@@ -2,7 +2,7 @@ import { TimeSlot } from "@/types/listingDetailPost.type";
 
 export type TimeLabel = "아침" | "점심" | "저녁";
 
-export const DEFAULT_SLOT: TimeSlot = { timeFrom: "00:00", timeTo: "00:00" };
+export const DEFAULT_SLOT: TimeSlot = { timeFrom: null, timeTo: null};
 export const DEFAULT_SLOTS: TimeSlot[] = [
   DEFAULT_SLOT,
   DEFAULT_SLOT,

--- a/src/hooks/common/useFunnel.ts
+++ b/src/hooks/common/useFunnel.ts
@@ -34,6 +34,10 @@ export const useFunnel = ({ steps }: { steps: readonly FunnelStep[] }) => {
     const sp = new URLSearchParams();
     sp.set("step", step);
     if (subStep) sp.set("subStep", subStep);
+
+    const draftId = searchParams.get("draftId");
+    if (draftId) sp.set("draftId", draftId);
+
     router.push(`${pathname}?${sp.toString()}`, { scroll: false });
   };
 
@@ -70,7 +74,7 @@ export const useFunnel = ({ steps }: { steps: readonly FunnelStep[] }) => {
     const { stepIndex, subStepIndex } = pos;
     const current = steps[stepIndex];
 
-    // ✅ subStep이 있는 스텝인데 현재 subStep이 잘못되었거나 빠져있는 경우
+    //  subStep이 있는 스텝인데 현재 subStep이 잘못되었거나 빠져있는 경우
     if (current.subSteps && subStepIndex === -1) {
       goTo(current.step, current.subSteps[0]); // 첫 subStep으로 강제 이동
       return;

--- a/src/hooks/property/createPayloadBySteps.tsx
+++ b/src/hooks/property/createPayloadBySteps.tsx
@@ -13,10 +13,11 @@ type StepKey =
 export function createPayloadByStep(
   step: StepKey,
   store: UseListingStoreReturn,
-  draftData?: Partial<TemporaryPropertyPost>,
+  draftData?: Partial<TemporaryPropertyPost> | null,
 ): Partial<TemporaryPropertyPost> {
   const base = {
     ...draftData,
+    stats: step,
     kind: store.listingType ?? "RENT",
     jsonDiscriminator: store.listingType ?? "RENT",
   };

--- a/src/hooks/property/createPayloadBySteps.tsx
+++ b/src/hooks/property/createPayloadBySteps.tsx
@@ -1,0 +1,94 @@
+import { UseListingStoreReturn } from "@/stores/useListingStore";
+
+import { TemporaryPropertyPost } from "@/types/temporaryProperty.type";
+
+type StepKey =
+  | "ADDRESS_PHOTO"
+  | "LISTING_DETAILS"
+  | "MOVING_CONDITIONS"
+  | "CONTRACT_TERMS"
+  | "LISTING_DESCRIPTION"
+  | "CREATE_CONFIRM";
+
+export function createPayloadByStep(
+  step: StepKey,
+  store: UseListingStoreReturn,
+  draftData?: Partial<TemporaryPropertyPost>,
+): Partial<TemporaryPropertyPost> {
+  const base = {
+    ...draftData,
+    kind: store.listingType ?? "RENT",
+    jsonDiscriminator: store.listingType ?? "RENT",
+  };
+  switch (step) {
+    case "ADDRESS_PHOTO":
+      return {
+        ...base,
+        region: store.region,
+        photoUrls: store.photoUrls,
+      };
+
+    case "LISTING_DETAILS": {
+      const basePayload = createPayloadByStep(
+        "ADDRESS_PHOTO",
+        store,
+        draftData,
+      );
+
+      if (store.listingType === "RENT") {
+        return {
+          ...basePayload,
+          rentPropertySubType: store.rentPropertyType,
+          capacityRent: store.rentCapacityPeople,
+          internalDetails: store.rentInternalDetails,
+          // SHARE 관련 필드는 null로 명시
+          sharePropertySubType: null,
+          capacityShare: null,
+          optionItemIds: store.optionItemIds,
+        };
+      } else if (store.listingType === "SHARE") {
+        return {
+          ...basePayload,
+          sharePropertySubType: store.sharePropertyType,
+          capacityShare: store.shareCapacityPeople,
+          internalDetails: store.shareInternalDetails,
+          // RENT 관련 필드는 null로 명시
+          rentPropertySubType: null,
+          capacityRent: null,
+          optionItemIds: store.optionItemIds,
+        };
+      } else {
+        return basePayload;
+      }
+    }
+    case "MOVING_CONDITIONS":
+      return {
+        ...createPayloadByStep("LISTING_DETAILS", store, draftData),
+        moveInInfo: store.moveInInfo,
+        livingConditions: store.livingConditions,
+        optionItemIds: store.optionItemIds,
+      };
+    case "CONTRACT_TERMS":
+      return {
+        ...createPayloadByStep("MOVING_CONDITIONS", store, draftData),
+        costDetails: store.costDetails,
+        meetingDateFrom: store.meetingDateFrom,
+        meetingDateTo: store.meetingDateTo,
+        viewingAlwaysAvailable: store.viewingAlwaysAvailable,
+        timeSlots:
+          store.timeSlots?.map(slot => ({
+            timeFrom: slot.timeFrom ?? "",
+            timeTo: slot.timeTo ?? "",
+          })) ?? [],
+      };
+    case "LISTING_DESCRIPTION":
+      return {
+        ...createPayloadByStep("CONTRACT_TERMS", store, draftData),
+        description: store.description,
+      };
+    case "CREATE_CONFIRM":
+      return createPayloadByStep("LISTING_DESCRIPTION", store, draftData);
+    default:
+      return draftData ?? {};
+  }
+}

--- a/src/hooks/property/createPayloadBySteps.tsx
+++ b/src/hooks/property/createPayloadBySteps.tsx
@@ -17,15 +17,15 @@ export function createPayloadByStep(
 ): Partial<TemporaryPropertyPost> {
   const base = {
     ...draftData,
-    status: step,
     kind: store.listingType ?? "RENT",
     jsonDiscriminator: store.listingType ?? "RENT",
+    region: store.region,
   };
   switch (step) {
     case "ADDRESS_PHOTO":
       return {
         ...base,
-        region: store.region,
+        status: step,
         photoUrls: store.photoUrls,
       };
 
@@ -77,10 +77,12 @@ export function createPayloadByStep(
     case "CONTRACT_TERMS":
       return {
         ...createPayloadByStep("MOVING_CONDITIONS", store, draftData),
+        status: step,
         costDetails: store.costDetails,
         meetingDateFrom: store.meetingDateFrom,
         meetingDateTo: store.meetingDateTo,
         viewingAlwaysAvailable: store.viewingAlwaysAvailable,
+        optionItemIds: store.optionItemIds,
         timeSlots:
           store.timeSlots?.map(slot => ({
             timeFrom: slot.timeFrom ?? "",
@@ -90,10 +92,15 @@ export function createPayloadByStep(
     case "LISTING_DESCRIPTION":
       return {
         ...createPayloadByStep("CONTRACT_TERMS", store, draftData),
+        status: step,
         description: store.description,
       };
     case "CREATE_CONFIRM":
-      return createPayloadByStep("LISTING_DESCRIPTION", store, draftData);
+      return {
+        ...createPayloadByStep("LISTING_DESCRIPTION", store, draftData),
+        status: step,
+      };
+
     default:
       return draftData ?? {};
   }

--- a/src/hooks/property/createPayloadBySteps.tsx
+++ b/src/hooks/property/createPayloadBySteps.tsx
@@ -70,6 +70,7 @@ export function createPayloadByStep(
         status: step,
         moveInInfo: store.moveInInfo,
         genderPreference: store.genderPreference,
+        lgbtAvailable: store.lgbtAvailable,
         livingConditions: store.livingConditions,
         optionItemIds: store.optionItemIds,
       };

--- a/src/hooks/property/createPayloadBySteps.tsx
+++ b/src/hooks/property/createPayloadBySteps.tsx
@@ -17,7 +17,7 @@ export function createPayloadByStep(
 ): Partial<TemporaryPropertyPost> {
   const base = {
     ...draftData,
-    stats: step,
+    status: step,
     kind: store.listingType ?? "RENT",
     jsonDiscriminator: store.listingType ?? "RENT",
   };
@@ -39,6 +39,7 @@ export function createPayloadByStep(
       if (store.listingType === "RENT") {
         return {
           ...basePayload,
+          status: step,
           rentPropertySubType: store.rentPropertyType,
           capacityRent: store.rentCapacityPeople,
           internalDetails: store.rentInternalDetails,
@@ -50,6 +51,7 @@ export function createPayloadByStep(
       } else if (store.listingType === "SHARE") {
         return {
           ...basePayload,
+          status: step,
           sharePropertySubType: store.sharePropertyType,
           capacityShare: store.shareCapacityPeople,
           internalDetails: store.shareInternalDetails,
@@ -65,7 +67,9 @@ export function createPayloadByStep(
     case "MOVING_CONDITIONS":
       return {
         ...createPayloadByStep("LISTING_DETAILS", store, draftData),
+        status: step,
         moveInInfo: store.moveInInfo,
+        genderPreference: store.genderPreference,
         livingConditions: store.livingConditions,
         optionItemIds: store.optionItemIds,
       };

--- a/src/hooks/property/useTimeSlotField.ts
+++ b/src/hooks/property/useTimeSlotField.ts
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
 
-import { convertLocalTimeToUtcString } from "@/utils/formatter/dateFormatter";
-import { convertUtcStringToLocalTime } from "@/utils/formatter/dateFormatter";
+import {
+  convertLocalTimeToUtcString,
+  convertUtcStringToLocalTime,
+} from "@/utils/formatter/dateFormatter";
 import { timeToMinutes } from "@/utils/listing/create/timeslotUtils";
 
 import {
@@ -29,7 +31,7 @@ export const useTimeSlotField = (
     // 그렇지 않으면 초기값 사용
     return initialSlots;
   });
-  
+
   const [tempTime, setTempTime] = useState<string | null>(null);
   const [activeSpinner, setActiveSpinner] = useState<{
     period: Period;
@@ -64,7 +66,7 @@ export const useTimeSlotField = (
     val: string,
   ) => {
     const { minTime, maxTime } = PERIOD_LIMITS[period];
-    let valMin = timeToMinutes(val);
+    const valMin = timeToMinutes(val);
     const minLimit = timeToMinutes(minTime);
     const maxLimit = timeToMinutes(maxTime === "00:00" ? "24:00" : maxTime);
 
@@ -74,29 +76,20 @@ export const useTimeSlotField = (
     }
 
     const idx = PERIODS.indexOf(period);
-    const otherValUtc =
+    const otherVal =
       slots[idx][type === "start" ? "timeTo" : "timeFrom"] || "00:00";
-    const otherValLocal = convertUtcStringToLocalTime(otherValUtc);
+    const localOtherVal = convertUtcStringToLocalTime(otherVal);
 
-    let otherMin = timeToMinutes(otherValLocal);
     if (type === "start") {
-      // 시작 시간이 종료 시간보다 같거나 크면 종료 시간에 24시간(1440분) 더함
-      if (otherMin <= valMin && otherValLocal !== "00:00") {
-        otherMin += 24 * 60;
+      if (val >= localOtherVal && localOtherVal !== "00:00") {
+        setAlertMsg("시작 시간은 종료 시간보다 이전이어야 합니다.");
+        return;
       }
-    } else if (type === "end") {
-      // 종료 시간이 시작 시간보다 같거나 작으면 종료 시간에 24시간 더함
-      if (valMin <= otherMin && val !== "00:00") {
-        valMin += 24 * 60;
+    } else {
+      if (val <= localOtherVal && val !== "00:00") {
+        setAlertMsg("시작 시간은 종료 시간보다 이전이어야 합니다.");
+        return;
       }
-    }
-
-    if (
-      (type === "start" && valMin >= otherMin && otherValLocal !== "00:00") ||
-      (type === "end" && valMin <= otherMin && val !== "00:00")
-    ) {
-      setAlertMsg("시작 시간은 종료 시간보다 이전이어야 합니다.");
-      return;
     }
 
     setTempTime(val);

--- a/src/hooks/property/useTimeSlotField.ts
+++ b/src/hooks/property/useTimeSlotField.ts
@@ -15,10 +15,21 @@ import { TimeSlot } from "@/types/listingDetailPost.type";
 type Period = (typeof PERIODS)[number];
 
 export const useTimeSlotField = (
-  value: TimeSlot[],
+  value: TimeSlot[] | null,
   onChange: (updated: TimeSlot[]) => void,
 ) => {
-  const [slots, setSlots] = useState<TimeSlot[]>(value);
+  const initialSlots: TimeSlot[] = PERIODS.map(() => ({
+    timeFrom: null,
+    timeTo: null,
+  }));
+
+  const [slots, setSlots] = useState<TimeSlot[]>(() => {
+    // value가 주어졌고 길이가 정확하면 그대로 사용
+    if (value?.length === PERIODS.length) return value;
+    // 그렇지 않으면 초기값 사용
+    return initialSlots;
+  });
+  
   const [tempTime, setTempTime] = useState<string | null>(null);
   const [activeSpinner, setActiveSpinner] = useState<{
     period: Period;
@@ -31,6 +42,10 @@ export const useTimeSlotField = (
   } | null>(null);
 
   useEffect(() => {
+    if (!value) {
+      setSlots(DEFAULT_SLOTS);
+      return;
+    }
     const isSame =
       value.length === slots.length &&
       value.every(

--- a/src/stores/useListingStore.ts
+++ b/src/stores/useListingStore.ts
@@ -56,7 +56,7 @@ interface ListingState {
   optionItemIds: number[];
   setOptionItemIds: (ids: number[]) => void;
 
-  timeSlots: TimeSlot[];
+  timeSlots: TimeSlot[] | null;
   setTimeSlots: (data: TimeSlot[]) => void;
 
   meetingDateFrom: string | null;

--- a/src/stores/useListingStore.ts
+++ b/src/stores/useListingStore.ts
@@ -75,8 +75,8 @@ interface ListingState {
   lgbtAvailable: boolean;
   setLgbtAvailable: (value: boolean) => void;
 
-  moveInInfo: MoveInInfo;
-  setMoveInInfo: (value: MoveInInfo) => void;
+  moveInInfo: MoveInInfo | null;
+  setMoveInInfo: (value: MoveInInfo | null) => void;
 
   livingConditions: LivingConditions | null;
   setLivingConditions: (value: LivingConditions | null) => void;

--- a/src/types/temporaryProperty.type.ts
+++ b/src/types/temporaryProperty.type.ts
@@ -11,7 +11,7 @@ import {
 } from "./listingDetailPost.type";
 
 export type FunnelSteps =
-  | "ADDRESS_PHOTO "
+  | "ADDRESS_PHOTO"
   | "LISTING_DETAILS"
   | "MOVING_CONDITIONS"
   | "CONTRACT_TERMS"
@@ -67,6 +67,7 @@ export interface ViewingAvailableDateTime {
 interface TemporaryPropertyBase {
   jsonDiscriminator: PropertySuperType;
   id?: number;
+  status: FunnelSteps;
   kind: PropertySuperType; // "RENT" | "SHARE"
   genderPreference?: GenderPreference | null;
   lgbtAvailable?: boolean | null;

--- a/src/types/temporaryProperty.type.ts
+++ b/src/types/temporaryProperty.type.ts
@@ -21,7 +21,7 @@ export type FunnelSteps =
 export interface TemporaryPropertyId {
   temporaryPropertyId: number;
   createdAt: string;
-  lastStep: FunnelSteps;
+  status: FunnelSteps;
 }
 
 export interface TemporaryCostDetails {
@@ -43,8 +43,8 @@ export interface TemporaryLivingConditions {
 export interface TemporaryMoveInInfo {
   availableFrom: string; // ISO datetime
   availableTo: string; // ISO datetime
-  isImmediate: boolean;
-  isNegotiable: boolean;
+  immediate: boolean;
+  negotiable: boolean;
 }
 
 export interface TemporaryTimeSlot {
@@ -66,35 +66,35 @@ export interface ViewingAvailableDateTime {
 
 interface TemporaryPropertyBase {
   jsonDiscriminator: PropertySuperType;
-  id: number;
+  id?: number;
   kind: PropertySuperType; // "RENT" | "SHARE"
-  genderPreference: GenderPreference | null;
-  lgbtAvailable: boolean | null;
+  genderPreference?: GenderPreference | null;
+  lgbtAvailable?: boolean | null;
   region: PropertyRegion | null;
   photoUrls: string[] | null;
-  costDetails: TemporaryCostDetails | null;
-  optionItemIds: number[] | null;
-  livingConditions: TemporaryLivingConditions | null;
-  moveInInfo: TemporaryMoveInInfo | null;
-  meetingDateFrom: string | null; //isoDate
-  meetingDateTo: string | null; // isoDate
-  timeSlots: TemporaryTimeSlot[] | null;
-  viewingAvailableDateTimes: ViewingAvailableDateTime[] | null;
-  viewingAlwaysAvailable: boolean | null;
-  description: string | null;
-  createdAt: string | null; // ISO date
+  costDetails?: TemporaryCostDetails | null;
+  optionItemIds?: number[] | null;
+  livingConditions?: TemporaryLivingConditions | null;
+  moveInInfo?: TemporaryMoveInInfo | null;
+  meetingDateFrom?: string | null; //isoDate
+  meetingDateTo?: string | null; // isoDate
+  timeSlots?: TemporaryTimeSlot[] | null;
+  viewingAvailableDateTimes?: ViewingAvailableDateTime[] | null;
+  viewingAlwaysAvailable?: boolean | null;
+  description?: string | null;
+  createdAt?: string | null; // ISO date
+  sharePropertySubType?: SharePropertySubType | null;
+  capacityShare?: CapacityShare | null;
+  rentPropertySubType?: RentPropertySubType | null;
+  capacityRent?: CapacityRent | null;
 }
 
 export interface ShareTemporaryProperty extends TemporaryPropertyBase {
-  internalDetails: ShareInternalDetails | null;
-  sharePropertySubType?: SharePropertySubType | null;
-  capacityShare?: CapacityShare | null;
+  internalDetails?: ShareInternalDetails | null;
 }
 
 export interface RentTemporaryProperty extends TemporaryPropertyBase {
-  internalDetails: RentInternalDetails | null;
-  rentPropertySubType?: RentPropertySubType | null;
-  capacityRent?: CapacityRent | null;
+  internalDetails?: RentInternalDetails | null;
 }
 
 export type TemporaryPropertyPost =

--- a/src/types/temporaryProperty.type.ts
+++ b/src/types/temporaryProperty.type.ts
@@ -1,10 +1,13 @@
-import { OptionItem } from "./listingDetailGet.type";
 import {
+  CapacityRent,
+  CapacityShare,
   GenderPreference,
   PropertyRegion,
   PropertySuperType,
   RentInternalDetails,
+  RentPropertySubType,
   ShareInternalDetails,
+  SharePropertySubType,
 } from "./listingDetailPost.type";
 
 export type FunnelSteps =
@@ -61,7 +64,8 @@ export interface ViewingAvailableDateTime {
   reserved: boolean;
 }
 
-export interface TemporaryProperty {
+interface TemporaryPropertyBase {
+  jsonDiscriminator: PropertySuperType;
   id: number;
   kind: PropertySuperType; // "RENT" | "SHARE"
   genderPreference: GenderPreference | null;
@@ -69,7 +73,7 @@ export interface TemporaryProperty {
   region: PropertyRegion | null;
   photoUrls: string[] | null;
   costDetails: TemporaryCostDetails | null;
-  optionItems: OptionItem[] | null;
+  optionItemIds: number[] | null;
   livingConditions: TemporaryLivingConditions | null;
   moveInInfo: TemporaryMoveInInfo | null;
   meetingDateFrom: string | null; //isoDate
@@ -79,7 +83,20 @@ export interface TemporaryProperty {
   viewingAlwaysAvailable: boolean | null;
   description: string | null;
   createdAt: string | null; // ISO date
-  // 내부 구조는 kind에 따라 아래 둘 중 하나만 존재:
-  shareInternalDetails?: ShareInternalDetails | null;
-  rentInternalDetails?: RentInternalDetails | null;
 }
+
+export interface ShareTemporaryProperty extends TemporaryPropertyBase {
+  internalDetails: ShareInternalDetails | null;
+  sharePropertySubType?: SharePropertySubType | null;
+  capacityShare?: CapacityShare | null;
+}
+
+export interface RentTemporaryProperty extends TemporaryPropertyBase {
+  internalDetails: RentInternalDetails | null;
+  rentPropertySubType?: RentPropertySubType | null;
+  capacityRent?: CapacityRent | null;
+}
+
+export type TemporaryPropertyPost =
+  | ShareTemporaryProperty
+  | RentTemporaryProperty;

--- a/src/utils/listing/create/answerHelpers.ts
+++ b/src/utils/listing/create/answerHelpers.ts
@@ -87,6 +87,7 @@ export const getAnswerText = (
 
   switch (id) {
     case "isBrokered":
+      if (!answer) return "";
       return answer === 54 ? "개인임대" : "부동산 중개";
     case "highlights": {
       const highlights = answer as number[];


### PR DESCRIPTION
### 🔥 작업 내용

- funnel 단계 별로 매물 등록 임시저장 되도록 허용
- 각 단계의 모든 응답이 이루어졌을 때 buttonAction bar 노출시킴 처리
- draft가 있는 경우에 backHeader에서 이전 단계로 이동되도록 처리


### 🤔 추후 작업 사항

- timeslot에서 null이 있는 경우에 임시저장이 안되는 경우가 존재ㅠ
(매물등록에서는 백에서 이미 바꿨는데, 임시저장에서는 처리가 안된듯)
- createdAt을 post로 보내는거는 아니라서 백에서 누적처리 해줘야하는데 안된듯 함.....ㅜ


### 📸 작업 내역 스크린샷

-

### 🔗 이슈

- #110 
